### PR TITLE
Fix dragger oscillation

### DIFF
--- a/enerdata/profiles/__init__.py
+++ b/enerdata/profiles/__init__.py
@@ -8,6 +8,10 @@ from decimal import Decimal
 class Dragger(Counter):
 
     def drag(self, number, key='default'):
+        if number == 0 and abs(self[key]) == 0.5:
+            # Avoid oscillation between -1 and 1 and dragging 0.5 and -0.5
+            return number
+
         number = Decimal(str(number)) + self[key]
         aprox = int(round(number))
         self[key] = number - aprox

--- a/spec/profiles/dragger_spec.py
+++ b/spec/profiles/dragger_spec.py
@@ -51,3 +51,15 @@ with description('A dragger object'):
                 aprox = d.drag(32.453)
                 aprox2 = d.drag(1.046)
                 expect(aprox2).to(be(1))
+
+        with context('if receives 0.5 and 0'):
+            with it('has to drag -0.5 and return 1 and 0'):
+                d = Dragger()
+                approx = d.drag(0.5)
+                dragging = d['default']
+                expect(approx).to(equal(1))
+                expect(dragging).to(equal(-0.5))
+                aprox = d.drag(0)
+                dragging = d['default']
+                expect(aprox).to(equal(0))
+                expect(dragging).to(equal(-0.5))


### PR DESCRIPTION
If dragger receives 0.5 and 0s, it returns an oscillation between 1 and -1 dragging -0.5 and 0.5.
This pull request fixes it and adds a spec to specify that it must return 1 and 0s and dragging -0.5.