### PR TITLE
Use _replace and unpack the dictionary to adjust profile measure

### DIFF
--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -413,7 +413,7 @@ class Profile(object):
                     values['measure'] = dragger.drag(measure.measure * (
                         balance[period] / energy_per_period[period]
                     ))
-                profile.measures[idx] = measure._make(values.values())
+                profile.measures[idx] = measure._replace(**values)
         return profile
 
     def fixit(self, tariff, balance, diff=0):


### PR DESCRIPTION
 instead of use make with values to avoid problems with the lack of OrderedDict in python 2.6