### PR TITLE
Estimate using balance for this period if exist

### DIFF
--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -339,7 +339,10 @@ class Profile(object):
         consumption_per_period = self.get_consumption_per_period(tariff)
         estimable = {}
         for period in consumption_per_period:
-            estimable[period] = balance[period] - consumption_per_period[period]
+            if period in balance:
+                estimable[period] = balance[period] - consumption_per_period[period]
+            else:
+                estimable[period] = -consumption_per_period[period]
         return estimable
 
     def estimate(self, tariff, balance):

--- a/spec/profiles/profile_spec.py
+++ b/spec/profiles/profile_spec.py
@@ -388,3 +388,7 @@ with description('A profile'):
     with it('shouldn\'t have estimable hours'):
         estimable_hours = self.profile.get_estimable_hours(T20DHA())
         expect(sum(estimable_hours.values())).to(equal(0))
+
+    with it('can handle partial filled profiles (without all tariff periods defined)'):
+        t = T30A()
+        print self.profile.estimate(t, {str('P2'): int(5)})


### PR DESCRIPTION
If not exist any balance for the current period, estimate just the consumption for this period.

fix #50 

Solves the error related to a estimation using partial filled profiles (without all the tariff periods described)

```
  estimacio = p.estimate(t, {str(periode): int(consum)})

  File "/home/k/libs/enerdata/enerdata/profiles/profile.py", line 376, in estimate
    energy_per_period = self.get_estimable_consumption(tariff, balance)

  File "/home/k/libs/enerdata/enerdata/profiles/profile.py", line 351, in get_estimable_consumption
    estimable[period] = balance[period] - consumption_per_period[period]

KeyError: 'P1'
```

Calling p.estimate from a measures-file inspection:
ES00XXXXXXXXX;2015-12-22;2016-01-22;2.0DHA;F1;N;**P2**;770;8905;9675x

The patch permit to go forward on the estimation process just taking care about the balance for the informed periods on the profile.

If more detail is needed just warn me.
