### PR TITLE
FIX Adjust per period

### DIFF
--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -271,6 +271,7 @@ class Profile(object):
     def __init__(self, start, end, measures):
         self.measures = measures[:]
         self.gaps = []  # Containing the gaps and invalid measures
+        self.adjusted_periods = [] # If a period is adjusted
         self.start_date = start
         self.end_date = end
         self.profile_class = REEProfile
@@ -404,6 +405,7 @@ class Profile(object):
             period_balance = balance[period_name]
             period_profile = energy_per_period[period_name]
             if not period_balance - diff <= period_profile <= period_balance + diff:
+                profile.adjusted_periods.append(period_name)
                 for idx, measure in enumerate(profile.measures):
                     period = tariff.get_period_by_date(measure.date).code
                     if period != period_name:


### PR DESCRIPTION
Adjusting was not done by period but per total consumption. Following point 4.6 from procedure 10.12 must be done by period and +/-1kWh comparison must also be done by period.

There is also a problem when adjusting but i do not exactly know how to do it. When a period must be adjusted all the hours must be marked as ```kind_fact = 3```. By now it is done comparing if the original value is equal to the adjusted one, and this is not correct. Enerdata should mark someway the adjusted hours, so the erp knows it has been adjusted, independent from the value obtained when adjusting.

