### PR TITLE
Fix: Tariff wouldn't accept some normalized powers

### DIFF
--- a/enerdata/contracts/tariff.py
+++ b/enerdata/contracts/tariff.py
@@ -125,7 +125,7 @@ class Tariff(object):
     def are_powers_normalized(powers):
         np = NormalizedPower()
         for power in powers:
-            if not np.is_normalized(power * 1000):
+            if not np.is_normalized(int(power * 1000)):
                 return False
 
         return True
@@ -199,7 +199,7 @@ class T20A(Tariff):
             pass
 
         norm_power = NormalizedPower().get_norm_powers(
-            self.min_power * 1000, self.max_power * 1000
+            int(self.min_power * 1000), int(self.max_power * 1000)
         ).next()
 
         return [norm_power / 1000.0] * len(self.power_periods)

--- a/spec/contracts/tariff_spec.py
+++ b/spec/contracts/tariff_spec.py
@@ -181,6 +181,9 @@ with context('A tariff'):
             lambda: tari_T61B.evaluate_powers([500, 600, 700, 700, 600, 500])
         ).to(
             raise_error(NotAscendingPowers))
+    with it('shouldn\'t fail due to bad rounding'):
+        tari_T20A = T20A()
+        assert tari_T20A.evaluate_powers([8050.0/1000])
     with it('should allow to check if a maximum power is correct'):
         tari_T20A = T20A()
         assert not tari_T20A.is_maximum_power_correct(-10)


### PR DESCRIPTION
Fixed a bug where tariff would say that some normalized powers are not normalized due to wrong rounding.