### PR TITLE
Add special key to disable dragger

### DIFF
--- a/enerdata/profiles/__init__.py
+++ b/enerdata/profiles/__init__.py
@@ -8,6 +8,8 @@ from decimal import Decimal
 class Dragger(Counter):
 
     def drag(self, number, key='default'):
+        if key == 'disabled':
+            return number
         if number == 0 and abs(self[key]) == Decimal('0.5'):
             # Avoid oscillation between -1 and 1 and dragging 0.5 and -0.5
             return number

--- a/spec/profiles/dragger_spec.py
+++ b/spec/profiles/dragger_spec.py
@@ -34,6 +34,11 @@ with description('A dragger object'):
         expect(aprox).to(be(6))
         expect(d['key2']).to(equal(Decimal('-0.5')))
 
+    with it('has a special key "disabled" which returns the number'):
+        d = Dragger()
+        aprox = d.drag(1.123456789, key='disabled')
+        expect(aprox).to(equal(1.123456789))
+
 
     with context('Has to use the drag of antecesor drag'):
 


### PR DESCRIPTION
* Add a special key **disabled** to disable dragger

```python
d =Dragger()
aprox = d.drag(1.23456789, key='disabled')
assert aprox == 1.23456789
```