### PR TITLE
ProfileHour with accumulated drag

### DIFF
--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -388,8 +388,8 @@ class Profile(object):
                     gap, aprox, period.code,
                     energy_per_period_rem[period.code], energy
             ))
-            pos = bisect.bisect_left(measures, ProfileHour(gap, 0, True))
-            profile_hour = ProfileHour(TIMEZONE.normalize(gap), aprox, True)
+            pos = bisect.bisect_left(measures, ProfileHour(gap, 0, True, 0.0))
+            profile_hour = ProfileHour(TIMEZONE.normalize(gap), aprox, True, dragger[drag_key])
             measures.insert(pos, profile_hour)
         profile = Profile(self.start_date, self.end_date, measures)
         return profile

--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -247,7 +247,7 @@ class REEProfile(object):
             cls.down_lock.release()
 
 
-class ProfileHour(namedtuple('ProfileHour', ['date', 'measure', 'valid'])):
+class ProfileHour(namedtuple('ProfileHour', ['date', 'measure', 'valid', 'accumulated'])):
 
     __slots__ = ()
 

--- a/spec/profiles/gaps_spec.py
+++ b/spec/profiles/gaps_spec.py
@@ -19,7 +19,7 @@ with description('A profile with gaps'):
         self.complete_profile = []
         while start_idx <= end:
             energy = random.randint(0, 10)
-            self.complete_profile.append(ProfileHour(start_idx, energy, True))
+            self.complete_profile.append(ProfileHour(start_idx, energy, True, 0.0))
             if gap_start < start_idx < gap_end:
                 self.gaps.append(start_idx)
                 start_idx += timedelta(hours=1)
@@ -31,7 +31,7 @@ with description('A profile with gaps'):
             else:
                 valid = True
             measures.append(ProfileHour(
-                TIMEZONE.normalize(start_idx), energy, valid
+                TIMEZONE.normalize(start_idx), energy, valid, 0.0
             ))
             start_idx += timedelta(hours=1)
         self.profile = Profile(start, end, measures)
@@ -112,7 +112,7 @@ with description('A profile with gaps'):
             for ph in self.complete_profile:
                 period = tariff.get_period_by_date(ph.date)
                 balance[period.code] += ph.measure
-                measures.append(ProfileHour(ph.date, ph.measure, False))
+                measures.append(ProfileHour(ph.date, ph.measure, False, 0.0))
 
             profile = Profile(
                 self.profile.start_date, self.profile.end_date, measures
@@ -140,7 +140,7 @@ with description('A profile with gaps'):
             for gap in self.profile.gaps:
                 pos = bisect.bisect_left(
                     profile_estimated.measures,
-                    ProfileHour(gap, 0, True)
+                    ProfileHour(gap, 0, True, 0.0)
                 )
                 measure = profile_estimated.measures[pos]
                 expect(measure.measure).to(equal(0))
@@ -179,7 +179,7 @@ with description('A complete profile with different energy than balance'):
         while start_idx <= end:
             energy = random.randint(0, 10)
             measures.append(ProfileHour(
-                TIMEZONE.normalize(start_idx), energy, True
+                TIMEZONE.normalize(start_idx), energy, True, 0.0
             ))
             start_idx += timedelta(hours=1)
         self.profile = Profile(start, end, measures)
@@ -219,7 +219,7 @@ with description('A complete profile with different energy than balance'):
                 balance = Counter()
 
                 measures = [
-                    ProfileHour(m.date, m.measure * 1000, m.valid)
+                    ProfileHour(m.date, m.measure * 1000, m.valid, 0.0)
                         for m in self.profile.measures
                 ]
                 profile = Profile(
@@ -263,8 +263,6 @@ with description('A complete profile with different energy than balance'):
 
                 balance[period.code] += 10
                 adjusted_periods = [period.code]
-
-
 
                 total_energy = sum(balance.values())
                 expect(total_energy).to(be_above(self.profile.total_consumption))

--- a/spec/profiles/gaps_spec.py
+++ b/spec/profiles/gaps_spec.py
@@ -2,7 +2,7 @@ from enerdata.profiles.profile import *
 from enerdata.contracts.tariff import *
 from expects import *
 import vcr
-
+from decimal import Decimal
 
 with description('A profile with gaps'):
     with before.all:
@@ -80,6 +80,9 @@ with description('A profile with gaps'):
             balance[period.code] += ph.measure
         with vcr.use_cassette('spec/fixtures/ree/201503-201504.yaml'):
             profile_estimated = self.profile.estimate(tariff, balance)
+
+        for a_profile in profile_estimated.measures:
+            assert type(a_profile.accumulated) == float or isinstance(a_profile.accumulated, Decimal), "Accumulated must be inside a ProfileHour and must be a float or a Decimal instance"
 
         total_energy = sum(balance.values())
         expect(profile_estimated.total_consumption).to(equal(total_energy))

--- a/spec/profiles/integration_spec.py
+++ b/spec/profiles/integration_spec.py
@@ -32,6 +32,7 @@ def convert_to_profilehour(measure):
         localize_season(measure['timestamp'], measure['season']),
         measure['ai'],
         measure['valid'],
+        0.0, 
         meta=measure
     )
     return ph

--- a/spec/profiles/profile_spec.py
+++ b/spec/profiles/profile_spec.py
@@ -406,7 +406,7 @@ with description('A profile'):
         start_idx = start
         while start_idx <= end:
             measures.append(ProfileHour(
-                TIMEZONE.normalize(start_idx), random.randint(0, 10), True
+                TIMEZONE.normalize(start_idx), random.randint(0, 10), True, 0.0
             ))
             start_idx += timedelta(hours=1)
         self.profile = Profile(start, end, measures)


### PR DESCRIPTION
It improves the ProfileHour to store the `accumulated` energy to be used for the next hour.

Will be usefull at re-profiling / re-filling for partial points to be sure to correlate the pending amount of energy rounded on previous hour.

It updates the specs where a ProfileHour is used, and provide own specs to be sure that new property `accumulated` exists and at least one of them for a full month estimation is different than zero (statistically assertion).

Fix #84 Extend ProfileHour with next measure to accumulate