### PR TITLE
Profile initialization with an initial accumulated energy

### DIFF
--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -375,6 +375,9 @@ class Profile(object):
 
         dragger = Dragger()
 
+        print ()
+        print ()
+        print (tariff, start, end)
 
         # Initialize the Dragger with passed accumulated value
         init_drag_key = tariff.get_period_by_date(self.gaps[0]).code
@@ -392,9 +395,11 @@ class Profile(object):
             # the gaps
             if energy < 0:
                 energy = 0
+
             gap_energy = (energy * gap_cof) / cofs_per_period[period.code]
             aprox = dragger.drag(gap_energy, key=drag_key)
             energy_per_period_rem[period.code] -= gap_energy
+
             logger.debug(
                 'Energy for hour {0} is {1}. {2} Energy {3}/{4}'.format(
                     gap, aprox, period.code,
@@ -402,6 +407,9 @@ class Profile(object):
             ))
             pos = bisect.bisect_left(measures, ProfileHour(gap, 0, True, 0.0))
             profile_hour = ProfileHour(TIMEZONE.normalize(gap), aprox, True, dragger[drag_key])
+
+            print (idx, drag_key, gap, profile_hour)
+
             measures.insert(pos, profile_hour)
         profile = Profile(self.start_date, self.end_date, measures)
         return profile

--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -388,8 +388,8 @@ class Profile(object):
                     gap, aprox, period.code,
                     energy_per_period_rem[period.code], energy
             ))
-            pos = bisect.bisect_left(measures, ProfileHour(gap, 0, True))
-            profile_hour = ProfileHour(TIMEZONE.normalize(gap), aprox, True)
+            pos = bisect.bisect_left(measures, ProfileHour(gap, 0, True, 0.0))
+            profile_hour = ProfileHour(TIMEZONE.normalize(gap), aprox, True, dragger[drag_key])
             measures.insert(pos, profile_hour)
         profile = Profile(self.start_date, self.end_date, measures)
         return profile

--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -375,6 +375,11 @@ class Profile(object):
 
         dragger = Dragger()
 
+
+        # Initialize the Dragger with passed accumulated value
+        init_drag_key = tariff.get_period_by_date(self.gaps[0]).code
+        dragger.drag(self.accumulated, key=init_drag_key)
+
         for idx, gap in enumerate(self.gaps):
             logger.debug('Gap {0}/{1}'.format(
                 idx + 1, len(self.gaps)

--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -387,8 +387,8 @@ class Profile(object):
             logger.debug('Gap {0}/{1}'.format(
                 idx + 1, len(self.gaps)
             ))
-            drag_key = period.code
             period = tariff.get_period_by_date(gap)
+            drag_key = period.code
             gap_cof = cofs.get(gap).cof[tariff.cof]
             energy = energy_per_period[period.code]
             # If the balance[period] < energy_profile[period] fill with 0

--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -247,7 +247,7 @@ class REEProfile(object):
             cls.down_lock.release()
 
 
-class ProfileHour(namedtuple('ProfileHour', ['date', 'measure', 'valid'])):
+class ProfileHour(namedtuple('ProfileHour', ['date', 'measure', 'valid', 'accumulated'])):
 
     __slots__ = ()
 

--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -10,6 +10,7 @@ from datetime import datetime, date, timedelta
 from multiprocessing import Lock
 from StringIO import StringIO
 from dateutil.relativedelta import relativedelta
+from decimal import Decimal
 
 from enerdata.profiles import Dragger
 from enerdata.contracts.tariff import Tariff
@@ -268,13 +269,19 @@ class Profile(object):
     """A Profile object representing hours and consumption.
     """
 
-    def __init__(self, start, end, measures):
+    def __init__(self, start, end, measures, accumulated=None):
         self.measures = measures[:]
         self.gaps = []  # Containing the gaps and invalid measures
         self.adjusted_periods = [] # If a period is adjusted
         self.start_date = start
         self.end_date = end
         self.profile_class = REEProfile
+
+        self.accumulated = Decimal(0)
+        if accumulated:
+            assert type(accumulated) == float or isinstance(accumulated, Decimal), "Provided accumulated must be a Decimal or a float"
+            assert accumulated < 1 and accumulated > -1, "Provided accumulated '{}' must be -1 < accumulated < 1".format(accumulated)
+            self.accumulated = accumulated
 
         measures_by_date = dict(
             [(m.date, m.measure) for m in measures if m.valid]

--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -380,37 +380,39 @@ class Profile(object):
         print (tariff, start, end)
 
         # Initialize the Dragger with passed accumulated value
-        init_drag_key = tariff.get_period_by_date(self.gaps[0]).code
-        dragger.drag(self.accumulated, key=init_drag_key)
+        if len(self.gaps) > 0:
+            init_drag_key = tariff.get_period_by_date(self.gaps[0]).code
+            dragger.drag(self.accumulated, key=init_drag_key)
 
-        for idx, gap in enumerate(self.gaps):
-            logger.debug('Gap {0}/{1}'.format(
-                idx + 1, len(self.gaps)
-            ))
-            period = tariff.get_period_by_date(gap)
-            drag_key = period.code
-            gap_cof = cofs.get(gap).cof[tariff.cof]
-            energy = energy_per_period[period.code]
-            # If the balance[period] < energy_profile[period] fill with 0
-            # the gaps
-            if energy < 0:
-                energy = 0
+            for idx, gap in enumerate(self.gaps):
+                logger.debug('Gap {0}/{1}'.format(
+                    idx + 1, len(self.gaps)
+                ))
+                drag_key = period.code
+                period = tariff.get_period_by_date(gap)
+                gap_cof = cofs.get(gap).cof[tariff.cof]
+                energy = energy_per_period[period.code]
+                # If the balance[period] < energy_profile[period] fill with 0
+                # the gaps
+                if energy < 0:
+                    energy = 0
 
-            gap_energy = (energy * gap_cof) / cofs_per_period[period.code]
-            aprox = dragger.drag(gap_energy, key=drag_key)
-            energy_per_period_rem[period.code] -= gap_energy
+                gap_energy = (energy * gap_cof) / cofs_per_period[period.code]
+                aprox = dragger.drag(gap_energy, key=drag_key)
+                energy_per_period_rem[period.code] -= gap_energy
 
-            logger.debug(
-                'Energy for hour {0} is {1}. {2} Energy {3}/{4}'.format(
-                    gap, aprox, period.code,
-                    energy_per_period_rem[period.code], energy
-            ))
-            pos = bisect.bisect_left(measures, ProfileHour(gap, 0, True, 0.0))
-            profile_hour = ProfileHour(TIMEZONE.normalize(gap), aprox, True, dragger[drag_key])
+                logger.debug(
+                    'Energy for hour {0} is {1}. {2} Energy {3}/{4}'.format(
+                        gap, aprox, period.code,
+                        energy_per_period_rem[period.code], energy
+                ))
+                pos = bisect.bisect_left(measures, ProfileHour(gap, 0, True, 0.0))
+                profile_hour = ProfileHour(TIMEZONE.normalize(gap), aprox, True, dragger[drag_key])
 
-            print (idx, drag_key, gap, profile_hour)
+                print (idx, drag_key, gap, profile_hour)
 
-            measures.insert(pos, profile_hour)
+                measures.insert(pos, profile_hour)
+
         profile = Profile(self.start_date, self.end_date, measures)
         return profile
 

--- a/spec/profiles/gaps_spec.py
+++ b/spec/profiles/gaps_spec.py
@@ -19,7 +19,7 @@ with description('A profile with gaps'):
         self.complete_profile = []
         while start_idx <= end:
             energy = random.randint(0, 10)
-            self.complete_profile.append(ProfileHour(start_idx, energy, True))
+            self.complete_profile.append(ProfileHour(start_idx, energy, True, 0.0))
             if gap_start < start_idx < gap_end:
                 self.gaps.append(start_idx)
                 start_idx += timedelta(hours=1)
@@ -31,7 +31,7 @@ with description('A profile with gaps'):
             else:
                 valid = True
             measures.append(ProfileHour(
-                TIMEZONE.normalize(start_idx), energy, valid
+                TIMEZONE.normalize(start_idx), energy, valid, 0.0
             ))
             start_idx += timedelta(hours=1)
         self.profile = Profile(start, end, measures)
@@ -112,7 +112,7 @@ with description('A profile with gaps'):
             for ph in self.complete_profile:
                 period = tariff.get_period_by_date(ph.date)
                 balance[period.code] += ph.measure
-                measures.append(ProfileHour(ph.date, ph.measure, False))
+                measures.append(ProfileHour(ph.date, ph.measure, False, 0.0))
 
             profile = Profile(
                 self.profile.start_date, self.profile.end_date, measures
@@ -140,7 +140,7 @@ with description('A profile with gaps'):
             for gap in self.profile.gaps:
                 pos = bisect.bisect_left(
                     profile_estimated.measures,
-                    ProfileHour(gap, 0, True)
+                    ProfileHour(gap, 0, True, 0.0)
                 )
                 measure = profile_estimated.measures[pos]
                 expect(measure.measure).to(equal(0))
@@ -179,7 +179,7 @@ with description('A complete profile with different energy than balance'):
         while start_idx <= end:
             energy = random.randint(0, 10)
             measures.append(ProfileHour(
-                TIMEZONE.normalize(start_idx), energy, True
+                TIMEZONE.normalize(start_idx), energy, True, 0.0
             ))
             start_idx += timedelta(hours=1)
         self.profile = Profile(start, end, measures)
@@ -219,7 +219,7 @@ with description('A complete profile with different energy than balance'):
                 balance = Counter()
 
                 measures = [
-                    ProfileHour(m.date, m.measure * 1000, m.valid)
+                    ProfileHour(m.date, m.measure * 1000, m.valid, 0.0)
                         for m in self.profile.measures
                 ]
                 profile = Profile(
@@ -263,8 +263,6 @@ with description('A complete profile with different energy than balance'):
 
                 balance[period.code] += 10
                 adjusted_periods = [period.code]
-
-
 
                 total_energy = sum(balance.values())
                 expect(total_energy).to(be_above(self.profile.total_consumption))

--- a/spec/profiles/gaps_spec.py
+++ b/spec/profiles/gaps_spec.py
@@ -2,7 +2,7 @@ from enerdata.profiles.profile import *
 from enerdata.contracts.tariff import *
 from expects import *
 import vcr
-
+from decimal import Decimal
 
 with description('A profile with gaps'):
     with before.all:
@@ -80,6 +80,9 @@ with description('A profile with gaps'):
             balance[period.code] += ph.measure
         with vcr.use_cassette('spec/fixtures/ree/201503-201504.yaml'):
             profile_estimated = self.profile.estimate(tariff, balance)
+
+        for a_profile in profile_estimated.measures:
+            assert type(a_profile.accumulated) == float or isinstance(a_profile.accumulated, Decimal), "Accumulated must be inside a ProfileHour and must be a float or a Decimal instance"
 
         total_energy = sum(balance.values())
         expect(profile_estimated.total_consumption).to(equal(total_energy))

--- a/spec/profiles/integration_spec.py
+++ b/spec/profiles/integration_spec.py
@@ -32,6 +32,7 @@ def convert_to_profilehour(measure):
         localize_season(measure['timestamp'], measure['season']),
         measure['ai'],
         measure['valid'],
+        0.0, 
         meta=measure
     )
     return ph

--- a/spec/profiles/profile_spec.py
+++ b/spec/profiles/profile_spec.py
@@ -507,3 +507,4 @@ with description("An estimation"):
             last_accumulated = estimation.measures[-1].accumulated
             assert float(last_accumulated) == float(expected_last_accumulated), "Last accumulated '{}' must match the expected '{}'".format(last_accumulated, expected_last_accumulated)
 
+            accumulated = 2

--- a/spec/profiles/profile_spec.py
+++ b/spec/profiles/profile_spec.py
@@ -406,7 +406,7 @@ with description('A profile'):
         start_idx = start
         while start_idx <= end:
             measures.append(ProfileHour(
-                TIMEZONE.normalize(start_idx), random.randint(0, 10), True
+                TIMEZONE.normalize(start_idx), random.randint(0, 10), True, 0.0
             ))
             start_idx += timedelta(hours=1)
         self.profile = Profile(start, end, measures)

--- a/spec/profiles/profile_spec.py
+++ b/spec/profiles/profile_spec.py
@@ -457,3 +457,22 @@ with description("An estimation"):
         self.profile = Profile(self.start, self.end, self.measures)
 
 
+    with it("must analyze all hours if empty measures is provided"):
+        tariff = T20DHA()
+        periods = tariff.energy_periods
+
+        balance = {
+            'P1': 20,
+            'P2': 10,
+        }
+        total_expected = sum(balance.values())
+
+        estimation = self.profile.estimate(tariff, balance)
+        total_estimated = sum([x.measure for x in estimation.measures])
+
+        # [!] Number of hours must match
+        assert self.expected_number_of_hours == len(estimation.measures), "Number of hours '{}' must match the expected '{}'".format(len(estimation.measures), self.expected_number_of_hours)
+
+        # [!] Energy must match
+        assert total_expected == total_estimated, "Total energy '{}' must match the expected '{}'".format(total_estimated, total_expected)
+

--- a/spec/profiles/profile_spec.py
+++ b/spec/profiles/profile_spec.py
@@ -3,6 +3,7 @@ from enerdata.contracts.tariff import T20DHA, T30A, T31A
 from enerdata.metering.measure import *
 from expects import *
 import vcr
+import random
 
 
 
@@ -399,7 +400,6 @@ with description("When profiling"):
 
 with description('A profile'):
     with before.all:
-        import random
         measures = []
         start = TIMEZONE.localize(datetime(2015, 3, 1, 1))
         end = TIMEZONE.localize(datetime(2015, 4, 1, 0))
@@ -442,3 +442,18 @@ with description('A profile'):
     with it('shouldn\'t have estimable hours'):
         estimable_hours = self.profile.get_estimable_hours(T20DHA())
         expect(sum(estimable_hours.values())).to(equal(0))
+
+
+with description("An estimation"):
+    with before.all:
+
+        self.measures = []
+        self.start = TIMEZONE.localize(datetime(2017, 9, 1))
+        self.end = TIMEZONE.localize(datetime(2017, 9, 2))
+
+        dates_difference_seconds = (self.end - self.start).total_seconds()
+        # Invoice hours with fixed first hour (timedelta performs natural substraction, so first hour must be handled)
+        self.expected_number_of_hours = (dates_difference_seconds / 3600) + 1
+        self.profile = Profile(self.start, self.end, self.measures)
+
+

--- a/spec/profiles/profile_spec.py
+++ b/spec/profiles/profile_spec.py
@@ -507,4 +507,31 @@ with description("An estimation"):
             last_accumulated = estimation.measures[-1].accumulated
             assert float(last_accumulated) == float(expected_last_accumulated), "Last accumulated '{}' must match the expected '{}'".format(last_accumulated, expected_last_accumulated)
 
+
+        with it("must handle incorrect accumulated values"):
+            it_breaks = False
             accumulated = 2
+            try:
+                self.profile = Profile(self.start, self.end, self.measures, accumulated)
+            except:
+                it_breaks = True
+
+            assert it_breaks, "A >1 accumulated must not work"
+
+            it_breaks = False
+            accumulated = -5
+            try:
+                self.profile = Profile(self.start, self.end, self.measures, accumulated)
+            except:
+                it_breaks = True
+
+            assert it_breaks, "A <-1 accumulated must not work"
+
+            it_breaks = False
+            accumulated = "x"
+            try:
+                self.profile = Profile(self.start, self.end, self.measures, accumulated)
+            except:
+                it_breaks = True
+
+            assert it_breaks, "A non numeric accumulated must not work"

--- a/spec/profiles/profile_spec.py
+++ b/spec/profiles/profile_spec.py
@@ -476,3 +476,34 @@ with description("An estimation"):
         # [!] Energy must match
         assert total_expected == total_estimated, "Total energy '{}' must match the expected '{}'".format(total_estimated, total_expected)
 
+
+    with context("with accumulated energy"):
+        with it("must handle incorrect accumulated values"):
+            accumulated = Decimal(0.636)
+            self.profile = Profile(self.start, self.end, self.measures, accumulated)
+            tariff = T20DHA()
+            periods = tariff.energy_periods
+
+            # This scenario, with an initial accumulated of 0.636 will raise a -1 total energy with an ending accumulated of 0.333962070125
+            total_expected = 0
+            balance = {
+                'P1': 20,
+                'P2': 10,
+            }
+            expected_dragger_round = -1
+            total_expected = sum(balance.values()) + expected_dragger_round
+            expected_last_accumulated = Decimal(0.333962070125)
+
+            estimation = self.profile.estimate(tariff, balance)
+            total_estimated = sum([x.measure for x in estimation.measures])
+
+            # [!] Number of hours must match
+            assert self.expected_number_of_hours == len(estimation.measures), "Number of hours '{}' must match the expected '{}'".format(len(estimation.measures), self.expected_number_of_hours)
+
+            # [!] Energy must match
+            assert total_expected == total_estimated, "Total energy '{}' must match the expected '{}'".format(total_estimated, total_expected)
+
+            # [!] Last accumulated
+            last_accumulated = estimation.measures[-1].accumulated
+            assert float(last_accumulated) == float(expected_last_accumulated), "Last accumulated '{}' must match the expected '{}'".format(last_accumulated, expected_last_accumulated)
+


### PR DESCRIPTION
This provides a mechanism to be able to define an initial accumulated energy for a Profile.

It's handled passing a new argument at `Profile` initialitzation called `accumulated`, accomplishing:
- be a float or a Decimal instance
- -1> accumulated < 1

This accumulated is loaded for the period of the first gap of this Profile.

To clarify with @ecarreras  if a period-based accumulate must be handled, just to apply the accumulated for the defined period, instead of the period of the first hour.

Tests are provided to validate it

Fix #86 Pass possible initial accumulated at Profile init