### PR TITLE
Profile with eligible dragging method

### DIFF
--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -269,13 +269,16 @@ class Profile(object):
     """A Profile object representing hours and consumption.
     """
 
-    def __init__(self, start, end, measures, accumulated=None):
+    def __init__(self, start, end, measures, accumulated=None, drag_by_periods=True):
         self.measures = measures[:]
         self.gaps = []  # Containing the gaps and invalid measures
         self.adjusted_periods = [] # If a period is adjusted
         self.start_date = start
         self.end_date = end
         self.profile_class = REEProfile
+
+        assert type(drag_by_periods) == bool, "drag_by_periods must be a Boolean"
+        self.drag_by_periods = drag_by_periods
 
         self.accumulated = Decimal(0)
         if accumulated:

--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -380,8 +380,13 @@ class Profile(object):
 
         # Initialize the Dragger with passed accumulated value
         if len(self.gaps) > 0:
-            # init_drag_key = tariff.get_period_by_date(self.gaps[0]).code
-            init_drag_key = "hardcoded_key"
+
+            # Drag by_hours
+            if not self.drag_by_periods:
+                init_drag_key = "default"
+            else:
+                init_drag_key = tariff.get_period_by_date(self.gaps[0]).code
+
             dragger.drag(self.accumulated, key=init_drag_key)
 
             for idx, gap in enumerate(self.gaps):
@@ -390,8 +395,7 @@ class Profile(object):
                 ))
                 period = tariff.get_period_by_date(gap)
 
-                # drag_key = period.code
-                drag_key = "hardcoded_key"
+                drag_key = period.code if not self.drag_by_periods else "default"
 
                 gap_cof = cofs.get(gap).cof[tariff.cof]
                 energy = energy_per_period[period.code]

--- a/spec/profiles/profile_spec.py
+++ b/spec/profiles/profile_spec.py
@@ -571,6 +571,19 @@ with description("An estimation"):
             last_accumulated = estimation.measures[-1].accumulated
             assert float(last_accumulated) == float(expected_last_accumulated), "Last accumulated '{}' must match the expected '{}'".format(last_accumulated, expected_last_accumulated)
 
+            # [!] Now estimate it using a by hour dragging
+            # total energy will be +1kWh!
+            drag_by_perdiod = False
+            total_expected += 1
+            expected_last_accumulated = Decimal(2.2E-12)
+
+            self.profile = Profile(self.start, self.end, self.measures, accumulated, drag_by_perdiod)
+            estimation = self.profile.estimate(tariff, balance)
+            total_estimated_by_hour = sum([x.measure for x in estimation.measures])
+            last_accumulated_by_hour = estimation.measures[-1].accumulated
+            assert total_expected == total_estimated_by_hour, "Total energy dragged by hour '{}' must match the expected +1 '{}'".format(total_estimated_by_hour, total_expected)
+            assert float(last_accumulated_by_hour) == float(expected_last_accumulated), "Last accumulated by hour '{}' must match the expected '{}'".format(last_accumulated_by_hour, expected_last_accumulated)
+
 
         with it("must handle incorrect accumulated values"):
             it_breaks = False
@@ -599,3 +612,5 @@ with description("An estimation"):
                 it_breaks = True
 
             assert it_breaks, "A non numeric accumulated must not work"
+
+

--- a/spec/profiles/profile_spec.py
+++ b/spec/profiles/profile_spec.py
@@ -543,8 +543,9 @@ with description("An estimation"):
     with context("with accumulated energy"):
         with it("must handle accumulated values"):
             accumulated = Decimal(0.136)
-            self.profile = Profile(self.start, self.end, self.measures, accumulated)
-            tariff = T20DHA()
+            drag_by_perdiod = True
+            self.profile = Profile(self.start, self.end, self.measures, accumulated, drag_by_perdiod)
+            tariff = T21DHS()
             periods = tariff.energy_periods
 
             # This scenario, with an initial accumulated of 0.636 will raise a -1 total energy with an ending accumulated of 0.333962070125
@@ -552,9 +553,10 @@ with description("An estimation"):
             balance = {
                 'P1': 6.8,
                 'P2': 3,
+                'P3': 3.5,
             }
             total_expected = round(sum(balance.values()))
-            expected_last_accumulated = Decimal(-0.0639999999989999902300373833)
+            expected_last_accumulated = Decimal(0.3000000000036)
 
             estimation = self.profile.estimate(tariff, balance)
             total_estimated = sum([x.measure for x in estimation.measures])


### PR DESCRIPTION
Dragging method is now eligible at Profile initialization using the flag property `drag_by_period`.

If True, the dragging method is based on the period, if not, it will drag to the next gap.

Default drag method (if not provided) is based on perdiod to keep compatibility with existing enerdata.Profile usages.

Fix #101  Profile class must handle dragging method