### PR TITLE
Validate minpower in 3.0A

### DIFF
--- a/enerdata/contracts/tariff.py
+++ b/enerdata/contracts/tariff.py
@@ -39,6 +39,7 @@ class Tariff(object):
         self.code = code
         self._periods = tuple()
         self.cof = None
+        self.require_powers_avove_min_power = False
 
     @property
     def periods(self):
@@ -125,6 +126,12 @@ class Tariff(object):
     def is_maximum_power_correct(self, max_pow):
         return self.min_power < max_pow <= self.max_power
 
+    def is_minimum_powers_correct(self, min_pow):
+        if self.require_powers_avove_min_power:
+            return self.min_power < min_pow <= self.max_power
+        else:
+            return True
+
     @staticmethod
     def are_powers_normalized(powers):
         np = NormalizedPower()
@@ -141,6 +148,8 @@ class Tariff(object):
             raise IncorrectPowerNumber(len(powers), len(self.power_periods))
         if not self.is_maximum_power_correct(max(powers)):
             raise IncorrectMaxPower(max(powers), self.min_power, self.max_power)
+        if not self.is_minimum_powers_correct(min(powers)):
+            raise IncorrectMinPower(min(powers), self.min_power, self.max_power)
         if not self.are_powers_normalized(powers):
             raise NotNormalizedPower()
 
@@ -292,6 +301,7 @@ class T30A(Tariff):
         self.cof = 'C'
         self.min_power = 15
         self.max_power = 1000000
+        self.require_powers_avove_min_power = True
         self.type = 'BT'
         self.periods = (
             TariffPeriod(
@@ -393,6 +403,7 @@ class T31A(T30A):
         self.min_power = 1
         self.max_power = 450
         self.type = 'AT'
+        self.require_powers_avove_min_power = False
         self.periods = (
             TariffPeriod(
                 'P1', 'te',
@@ -545,6 +556,18 @@ class IncorrectPowerNumber(Exception):
 class IncorrectMaxPower(Exception):
     def __init__(self, power, min_power, max_power):
         super(IncorrectMaxPower, self).__init__(
+            'Power {0} is not between {1} and {2}'.format(
+                power, min_power, max_power
+            )
+        )
+        self.power = power
+        self.min_power = min_power
+        self.max_power = max_power
+
+
+class IncorrectMinPower(Exception):
+    def __init__(self, power, min_power, max_power):
+        super(IncorrectMinPower, self).__init__(
             'Power {0} is not between {1} and {2}'.format(
                 power, min_power, max_power
             )

--- a/enerdata/contracts/tariff.py
+++ b/enerdata/contracts/tariff.py
@@ -39,7 +39,7 @@ class Tariff(object):
         self.code = code
         self._periods = tuple()
         self.cof = None
-        self.require_powers_avove_min_power = False
+        self.require_powers_above_min_power = False
 
     @property
     def periods(self):
@@ -127,7 +127,7 @@ class Tariff(object):
         return self.min_power < max_pow <= self.max_power
 
     def is_minimum_powers_correct(self, min_pow):
-        if self.require_powers_avove_min_power:
+        if self.require_powers_above_min_power:
             return self.min_power < min_pow <= self.max_power
         else:
             return True
@@ -301,7 +301,7 @@ class T30A(Tariff):
         self.cof = 'C'
         self.min_power = 15
         self.max_power = 1000000
-        self.require_powers_avove_min_power = True
+        self.require_powers_above_min_power = True
         self.type = 'BT'
         self.periods = (
             TariffPeriod(
@@ -403,7 +403,7 @@ class T31A(T30A):
         self.min_power = 1
         self.max_power = 450
         self.type = 'AT'
-        self.require_powers_avove_min_power = False
+        self.require_powers_above_min_power = False
         self.periods = (
             TariffPeriod(
                 'P1', 'te',

--- a/spec/contracts/tariff_spec.py
+++ b/spec/contracts/tariff_spec.py
@@ -143,11 +143,13 @@ with context('A tariff'):
         tari_T30A = T30A()
         expect(lambda: tari_T30A.evaluate_powers([-10, -5, 0])).to(
             raise_error(NotPositivePower))
-        expect(lambda: tari_T30A.evaluate_powers([10, 13, 15])).to(
+        expect(lambda: tari_T30A.evaluate_powers([15, 15, 15])).to(
             raise_error(IncorrectMaxPower))
-        expect(lambda: tari_T30A.evaluate_powers([10, 13, 16])).to(
+        expect(lambda: tari_T30A.evaluate_powers([16, 17.1, 16])).to(
             raise_error(NotNormalizedPower))
-        assert tari_T30A.evaluate_powers([2.304, 2.304, 16.454])
+        expect(lambda: tari_T30A.evaluate_powers([14, 15.242, 15.242])).to(
+            raise_error(IncorrectMinPower))
+        assert tari_T30A.evaluate_powers([15.242, 15.242, 16.454])
         expect(lambda: tari_T30A.evaluate_powers([16, 17])).to(
             raise_error(IncorrectPowerNumber, 'Expected 3 power(s) and got 2'))
 


### PR DESCRIPTION
The tariff 3.0A has a new restriction: all powers must be above the min power.
This PR adds this validation to the method `evaluate_powers`.

Tariff powers:
https://rfc.gisce.net/t/codigos-de-agregaciones/423

Close https://github.com/gisce/enerdata/issues/104