### PR TITLE
Go back one day to download coefficients

### DIFF
--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -368,7 +368,7 @@ class Profile(object):
         measures = [x for x in self.measures if x.valid]
         start = self.start_date
         end = self.end_date
-        cofs = self.profile_class.get_range(start, end)
+        cofs = self.profile_class.get_range(start, end - relativedelta(days=1))
         cofs = Coefficients(cofs)
         cofs_per_period = Counter()
 

--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -308,6 +308,10 @@ class Profile(object):
     def total_consumption(self):
         return sum(x[1] for x in self.measures)
 
+    @staticmethod
+    def final_day_of_month(date_end):
+        return date_end.day == 1 and date_end.hour >= 1
+
     def get_hours_per_period(self, tariff, only_valid=False):
         assert isinstance(tariff, Tariff)
         hours_per_period = Counter()
@@ -368,7 +372,13 @@ class Profile(object):
         measures = [x for x in self.measures if x.valid]
         start = self.start_date
         end = self.end_date
-        cofs = self.profile_class.get_range(start, end - relativedelta(days=1))
+
+        if self.final_day_of_month(end):
+            cofs = self.profile_class.get_range(start, end)
+        else:
+            cofs = self.profile_class.get_range(
+                start, end - relativedelta(days=1)
+            )
         cofs = Coefficients(cofs)
         cofs_per_period = Counter()
 

--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -308,9 +308,9 @@ class Profile(object):
     def total_consumption(self):
         return sum(x[1] for x in self.measures)
 
-    @staticmethod
-    def final_day_of_month(date_end):
-        return date_end.day == 1 and date_end.hour >= 1
+    @property
+    def first_day_of_month(self):
+        return self.end_date.day == 1 and self.end_date.hour > 0
 
     def get_hours_per_period(self, tariff, only_valid=False):
         assert isinstance(tariff, Tariff)
@@ -373,7 +373,7 @@ class Profile(object):
         start = self.start_date
         end = self.end_date
 
-        if self.final_day_of_month(end):
+        if self.first_day_of_month:
             cofs = self.profile_class.get_range(start, end)
         else:
             cofs = self.profile_class.get_range(

--- a/spec/coefficients/coefficients_spec.py
+++ b/spec/coefficients/coefficients_spec.py
@@ -3,6 +3,21 @@ from dateutil.relativedelta import relativedelta
 from enerdata.profiles.profile import *
 from enerdata.datetime.station import *
 
+ONE_MONTH_DATE_SET = ['1/2018']
+DATE_SET = ['3/2018', '4/2018', '5/2018']
+
+def get_data_ranges(start, end):
+    from datetime import datetime
+    from dateutil.relativedelta import relativedelta
+    cofs = []
+    start = datetime(start.year, start.month, 1)
+    end = datetime(end.year, end.month, 1)
+    while start <= end:
+        cof = '{0}/{1}'.format(start.month, start.year)
+        cofs.append(cof)
+        start += relativedelta(months=1)
+    return cofs
+
 
 with description('Downloading coefficients '):
     with it('it should not include the final month'):
@@ -11,3 +26,25 @@ with description('Downloading coefficients '):
             datetime(2018, 5, 1, 0, 0) - relativedelta(days=1)
         )
         assert coeff[-1].hour.month == 5
+
+    with it('Final date end of month'):
+        di = datetime(2018, 3, 24, 0, 0)
+        df = datetime(2018, 6, 1, 0, 0)
+        assert get_data_ranges(di, df - relativedelta(days=1)) == DATE_SET
+
+    with it('Final date between month'):
+        di = datetime(2018, 3, 24, 0, 0)
+        df = datetime(2018, 5, 15, 0, 0)
+        assert get_data_ranges(di, df - relativedelta(days=1)) == DATE_SET
+
+    with it('One month invoice'):
+        di = datetime(2018, 1, 1, 1, 0)
+        df = datetime(2018, 1, 31, 0, 0)
+        assert get_data_ranges(
+            di, df - relativedelta(days=1)) == ONE_MONTH_DATE_SET
+
+    with it('One day invoice'):
+        di = datetime(2018, 1, 1, 1, 0)
+        df = datetime(2018, 1, 2, 0, 0)
+        assert get_data_ranges(
+            di, df - relativedelta(days=1)) == ONE_MONTH_DATE_SET

--- a/spec/coefficients/coefficients_spec.py
+++ b/spec/coefficients/coefficients_spec.py
@@ -18,8 +18,9 @@ def get_data_ranges(start, end):
         start += relativedelta(months=1)
     return cofs
 
-def final_day_of_month(end):
-    return end.day == 1 and end.hour >= 1
+def first_day_of_month(end):
+    return end.day == 1 and end.hour > 0
+
 
 with description('Downloading coefficients '):
     with it('it should not include the final month'):
@@ -32,7 +33,7 @@ with description('Downloading coefficients '):
     with it('Final date end of month'):
         di = datetime(2018, 3, 24, 0, 0)
         df = datetime(2018, 6, 1, 0, 0)
-        if final_day_of_month(df):
+        if first_day_of_month(df):
             assert get_data_ranges(di, df) == DATE_SET
         else:
             assert get_data_ranges(di, df - relativedelta(days=1)) == DATE_SET
@@ -40,7 +41,7 @@ with description('Downloading coefficients '):
     with it('Final date start of month'):
         di = datetime(2018, 3, 24, 0, 0)
         df = datetime(2018, 5, 1, 1, 0)
-        if final_day_of_month(df):
+        if first_day_of_month(df):
             assert get_data_ranges(di, df) == DATE_SET
         else:
             assert get_data_ranges(di, df - relativedelta(days=1)) == DATE_SET
@@ -48,7 +49,7 @@ with description('Downloading coefficients '):
     with it('Final date between month'):
         di = datetime(2018, 3, 24, 0, 0)
         df = datetime(2018, 5, 15, 0, 0)
-        if final_day_of_month(df):
+        if first_day_of_month(df):
             assert get_data_ranges(di, df) == DATE_SET
         else:
             assert get_data_ranges(di, df - relativedelta(days=1)) == DATE_SET
@@ -56,7 +57,7 @@ with description('Downloading coefficients '):
     with it('One month invoice'):
         di = datetime(2018, 1, 1, 1, 0)
         df = datetime(2018, 2, 1, 0, 0)
-        if final_day_of_month(df):
+        if first_day_of_month(df):
             assert get_data_ranges(di, df) == ONE_MONTH_DATE_SET
         else:
             assert get_data_ranges(
@@ -65,7 +66,7 @@ with description('Downloading coefficients '):
     with it('One day invoice'):
         di = datetime(2018, 1, 1, 1, 0)
         df = datetime(2018, 1, 2, 0, 0)
-        if final_day_of_month(df):
+        if first_day_of_month(df):
             assert get_data_ranges(di, df) == ONE_MONTH_DATE_SET
         else:
             assert get_data_ranges(
@@ -114,6 +115,3 @@ with description('Profiling...'):
             estimation = profile.estimate(tariff, balance)
         except Exception as err:
             assert err.message != "Profiles from REE not found"
-        finally:
-            assert start == estimation.start_date
-            assert end == estimation.end_date

--- a/spec/coefficients/coefficients_spec.py
+++ b/spec/coefficients/coefficients_spec.py
@@ -18,6 +18,8 @@ def get_data_ranges(start, end):
         start += relativedelta(months=1)
     return cofs
 
+def final_day_of_month(end):
+    return end.day == 1 and end.hour >= 1
 
 with description('Downloading coefficients '):
     with it('it should not include the final month'):
@@ -30,26 +32,41 @@ with description('Downloading coefficients '):
     with it('Final date end of month'):
         di = datetime(2018, 3, 24, 0, 0)
         df = datetime(2018, 6, 1, 0, 0)
-        assert get_data_ranges(di, df - relativedelta(days=1)) == DATE_SET
+        if final_day_of_month(df):
+            assert get_data_ranges(di, df) == DATE_SET
+        else:
+            assert get_data_ranges(di, df - relativedelta(days=1)) == DATE_SET
 
     with it('Final date start of month'):
         di = datetime(2018, 3, 24, 0, 0)
         df = datetime(2018, 5, 1, 1, 0)
-        assert get_data_ranges(di, df - relativedelta(days=1)) == DATE_SET
+        if final_day_of_month(df):
+            assert get_data_ranges(di, df) == DATE_SET
+        else:
+            assert get_data_ranges(di, df - relativedelta(days=1)) == DATE_SET
 
     with it('Final date between month'):
         di = datetime(2018, 3, 24, 0, 0)
         df = datetime(2018, 5, 15, 0, 0)
-        assert get_data_ranges(di, df - relativedelta(days=1)) == DATE_SET
+        if final_day_of_month(df):
+            assert get_data_ranges(di, df) == DATE_SET
+        else:
+            assert get_data_ranges(di, df - relativedelta(days=1)) == DATE_SET
 
     with it('One month invoice'):
         di = datetime(2018, 1, 1, 1, 0)
-        df = datetime(2018, 1, 31, 0, 0)
-        assert get_data_ranges(
-            di, df - relativedelta(days=1)) == ONE_MONTH_DATE_SET
+        df = datetime(2018, 2, 1, 0, 0)
+        if final_day_of_month(df):
+            assert get_data_ranges(di, df) == ONE_MONTH_DATE_SET
+        else:
+            assert get_data_ranges(
+                di, df - relativedelta(days=1)) == ONE_MONTH_DATE_SET
 
     with it('One day invoice'):
         di = datetime(2018, 1, 1, 1, 0)
         df = datetime(2018, 1, 2, 0, 0)
-        assert get_data_ranges(
-            di, df - relativedelta(days=1)) == ONE_MONTH_DATE_SET
+        if final_day_of_month(df):
+            assert get_data_ranges(di, df) == ONE_MONTH_DATE_SET
+        else:
+            assert get_data_ranges(
+                di, df - relativedelta(days=1)) == ONE_MONTH_DATE_SET

--- a/spec/coefficients/coefficients_spec.py
+++ b/spec/coefficients/coefficients_spec.py
@@ -1,0 +1,13 @@
+from enerdata.datetime import datetime
+from dateutil.relativedelta import relativedelta
+from enerdata.profiles.profile import *
+from enerdata.datetime.station import *
+
+
+with description('Downloading coefficients '):
+    with it('it should not include the final month'):
+        coeff = REEProfile.get_range(
+            datetime(2018, 3, 24, 0, 0),
+            datetime(2018, 5, 1, 0, 0) - relativedelta(days=1)
+        )
+        assert coeff[-1].hour.month == 5

--- a/spec/coefficients/coefficients_spec.py
+++ b/spec/coefficients/coefficients_spec.py
@@ -96,6 +96,24 @@ with description('Profiling...'):
         assert start == estimation.start_date
         assert end == estimation.end_date
 
+    with it("Profile with first day of month included"):
+        start = TIMEZONE.localize(datetime(2018, 1, 1, 1))
+        end = TIMEZONE.localize(datetime(2018, 2, 1, 1))
+        tariff = T20A()
+        accumulated = 0
+        balance = {
+            'P1': 6.8,
+            'P2': 3,
+            'P3': 3.5,
+        }
+
+        profile = Profile(start, end, self.measures, accumulated)
+        estimation = profile.estimate(tariff, balance)
+
+        assert self.expected_hours + 1 == len(estimation.measures)
+        assert start == estimation.start_date
+        assert end == estimation.end_date
+
     with it("Profile with current date to download REE coefficients last month"):
         end_year = datetime.now().year
         end_month = datetime.now().month

--- a/spec/coefficients/coefficients_spec.py
+++ b/spec/coefficients/coefficients_spec.py
@@ -32,6 +32,11 @@ with description('Downloading coefficients '):
         df = datetime(2018, 6, 1, 0, 0)
         assert get_data_ranges(di, df - relativedelta(days=1)) == DATE_SET
 
+    with it('Final date start of month'):
+        di = datetime(2018, 3, 24, 0, 0)
+        df = datetime(2018, 5, 1, 1, 0)
+        assert get_data_ranges(di, df - relativedelta(days=1)) == DATE_SET
+
     with it('Final date between month'):
         di = datetime(2018, 3, 24, 0, 0)
         df = datetime(2018, 5, 15, 0, 0)

--- a/spec/coefficients/coefficients_spec.py
+++ b/spec/coefficients/coefficients_spec.py
@@ -114,3 +114,6 @@ with description('Profiling...'):
             estimation = profile.estimate(tariff, balance)
         except Exception as err:
             assert err.message != "Profiles from REE not found"
+        finally:
+            assert start == estimation.start_date
+            assert end == estimation.end_date


### PR DESCRIPTION
Get only the coefficients of the full months.
The file PERF_YYYYMM.txt carries all the days and hours included as follows:

```
2018;05;31;22;1;0.000136069486;0.000111580212;0.000111439358;0.000124703211;
2018;05;31;23;1;0.000125455061;0.000146546331;0.000103533335;0.000213501071;
2018;05;31;24;1;0.000101257604;0.000143837286;0.000092411636;0.000189206101;
```

So, when you want coefficients up to date x: 00h, you have to pass in 24h format
Example:
start_date = 2018-02-01 01:00
end_date = 2018-04-01 00:00
Will try to find coefficients of the month 04 !!! In the file PERF_201803 you have the hour 24.

Good way :heavy_check_mark:
```Python
di = datetime.datetime(2018, 4, 1, 1, 0)
df = datetime.datetime(2018, 6, 1, 0, 0)
get_coeffs(di, df)
>>>
Downloading coefficients for 4/2018
Downloading coefficients for 5/2018
```

Bad way :warning: 
```Python
di = datetime.datetime(2018, 4, 1, 1, 0)
df = datetime.datetime(2018, 6, 1, 0, 0)
get_coeffs(di, df)
>>>
Downloading coefficients for 4/2018
Downloading coefficients for 5/2018
Downloading coefficients for 6/2018
```