### PR TITLE
Obtain profile coefficients using HTTPS

### DIFF
--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -207,7 +207,7 @@ class REEProfile(object):
                 logger.debug('Using CACHE for REEProfile {0}'.format(key))
                 return cls._CACHE[key]
             perff_file = 'PERFF_%(key)s.gz' % locals()
-            conn = httplib.HTTPConnection(cls.HOST)
+            conn = httplib.HTTPSConnection(cls.HOST)
             conn.request('GET', '%s/%s' % (cls.PATH, perff_file))
             logger.debug('Downloading REEProfile from {0}/{1}'.format(
                 cls.PATH, perff_file


### PR DESCRIPTION
www.ree.es has permanently moved its coefficient collection link
When you try to do `HTTPConnection()` a `www.ree.es`, it returns: **301 error code**

```Python
>>> conn = httplib.HTTPConnection(HOST)
>>> conn.reques('GET', '/sites/default/files/simel/perff/PERFF_201709.gz')
>>> r.status
301
``` 

Solving...
```Python
>>> conn = httplib.HTTPSConnection(HOST)
>>> conn.reques('GET', '/sites/default/files/simel/perff/PERFF_201709.gz')
>>> r.status
200
``` 