### PR TITLE
New normalized 100 W multiples power

### DIFF
--- a/enerdata/contracts/normalized_power.py
+++ b/enerdata/contracts/normalized_power.py
@@ -120,20 +120,25 @@ NORMALIZED_POWERS = {
     43648: ('3x400/230', '63')
 }
 
+NOT_NORMALIZED_100 = dict([(p, (None, None)) for p in range(100, 15001, 100)
+                           if p not in NORMALIZED_POWERS])
+
+ALL_POWERS = NOT_NORMALIZED_100.copy()
+ALL_POWERS.update(NORMALIZED_POWERS)
 
 class NormalizedPower(object):
 
     def get_volt_int(self, pot):
-        volt_int = NORMALIZED_POWERS.get(pot, None)
+        volt_int = ALL_POWERS.get(pot, None)
         if volt_int is None:
             raise ValueError('The given power is not normalized')
         return volt_int
 
     def is_normalized(self, pot):
-        return pot in NORMALIZED_POWERS
+        return pot in ALL_POWERS
 
     def get_norm_powers(self, pot_min, pot_max):
-        for norm_pow in sorted(NORMALIZED_POWERS):
+        for norm_pow in sorted(ALL_POWERS):
             if pot_min < norm_pow <= pot_max:
                 yield norm_pow
             elif norm_pow > pot_max:

--- a/spec/contracts/normalized_power_spec.py
+++ b/spec/contracts/normalized_power_spec.py
@@ -2,12 +2,21 @@
 from expects import expect, raise_error
 
 from enerdata.contracts.normalized_power import NormalizedPower
+from enerdata.contracts.normalized_power import NORMALIZED_POWERS as OFFICIAL_NP
 
 NORMALIZED_POWERS = {
     330: ('1x220', '1.5')
 }
 
-NOT_NORMALIZED_POWERS = [100]
+NOT_NORMALIZED_POWERS = [111]
+
+NOT_NORMALIZED_100 = range(100, 15001, 100)
+NORMALIZED_100 = []
+for power in OFFICIAL_NP:
+    try:
+        NOT_NORMALIZED_100.remove(power)
+    except ValueError:
+        continue
 
 with description('A normalized power class'):
     with context('if the power is normalized'):
@@ -35,11 +44,24 @@ with description('A normalized power class'):
     with it('must return all the normalized powers between two values in '
             'ascending order (the first one shouldn\'t included)'):
         n_p = NormalizedPower()
-        norm_power_01 = [191, 200, 330, 345, 381, 399, 445, 466, 572, 598, 635,
-                         660, 665, 690, 770, 805, 953, 987, 998]
+        norm_power_01 = [100, 191, 200, 300, 330, 345, 381, 399, 400, 445, 466,
+                         500, 572, 598, 600, 635, 660, 665, 690, 700, 770, 800,
+                         805, 900, 953, 987, 998, 1000]
 
-        norm_power_02 = [2300, 2304, 2425, 2540, 2660, 2858, 2988, 3175, 3291,
+        norm_power_02 = [2300, 2304, 2400, 2425, 2500, 2540, 2600, 2660, 2700,
+                         2800, 2858, 2900, 2988, 3000, 3100, 3175, 3200, 3291,
                          3300]
 
         assert list(n_p.get_norm_powers(0, 1000)) == norm_power_01
         assert list(n_p.get_norm_powers(2200, 3300)) == norm_power_02
+
+    with context('if the power is multiple of 100 W and not normalized'):
+        with it('must no return voltage'):
+            n_p = NormalizedPower()
+            for power in NOT_NORMALIZED_100:
+                assert n_p.get_volt_int(power) == (None, None)
+
+        with it('must not raise a ValueError Exception'):
+            n_p = NormalizedPower()
+            for normal in NOT_NORMALIZED_100:
+                assert n_p.is_normalized(normal)

--- a/spec/contracts/tariff_spec.py
+++ b/spec/contracts/tariff_spec.py
@@ -132,7 +132,7 @@ with context('A tariff'):
             raise_error(NotPositivePower))
         expect(lambda: tari_T20A.evaluate_powers([0])).to(
             raise_error(NotPositivePower))
-        expect(lambda: tari_T20A.evaluate_powers([5])).to(
+        expect(lambda: tari_T20A.evaluate_powers([5.55])).to(
             raise_error(NotNormalizedPower))
         assert tari_T20A.evaluate_powers([5.5])
         expect(lambda: tari_T20A.evaluate_powers([5, 7])).to(


### PR DESCRIPTION
Since RD 15/2018 https://www.boe.es/boe/dias/2018/10/06/pdfs/BOE-A-2018-13593.pdf, 2.0 and 2.1  Normalized Powers includes multiples of 100 W until 15000 W. 

This modifies `NormalizedPower` class:

* `get_vol_int`: returns `(None, None)` when is 100 W multiple and not an old NormalizedPower
* `is_normalized`: includes 100 W multiples
* `get_norm_powers`: includes 100 W multiples on returned list

