### PR TITLE
Fixed ZeroDivisionError error when having sun coefficients at zero

### DIFF
--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -491,7 +491,12 @@ class Profile(object):
                 if energy < 0:
                     energy = 0
 
-                gap_energy = (energy * gap_cof) / cofs_per_period[period.code]
+                try:
+                    gap_energy = (energy * gap_cof) / cofs_per_period[period.code]
+                except ZeroDivisionError as error:
+                    gap_energy = 0
+                    logger.debug(error)
+
                 aprox = dragger.drag(gap_energy, key=drag_key)
                 energy_per_period_rem[period.code] -= gap_energy
 

--- a/spec/profiles/profile_spec.py
+++ b/spec/profiles/profile_spec.py
@@ -415,10 +415,10 @@ with description("When profiling"):
             assert cons['P6'] == 0
 
         with context('And the tariff is RE'):
-            with fit('zero values for sun coefficient should not cause problems '):
-                measures = []
+            with it('zero values for sun coefficient should not cause problems '):
                 di = '2019-01-01 01:00:00'
-                df = '2019-02-01 00:00:00'
+                df = '2019-01-01 02:00:00'
+                measures = []
                 start = TIMEZONE.localize(datetime.strptime(di, '%Y-%m-%d %H:%M:%S'))
                 end = TIMEZONE.localize(datetime.strptime(df, '%Y-%m-%d %H:%M:%S'))
                 profile = Profile(start, end, measures)
@@ -429,10 +429,9 @@ with description("When profiling"):
                     'P0': 0
                 }
                 total_expected = 0
+                # This test only checks try/except for ZeroDivisionError works
                 estimation = profile.estimate(tariff, balance)
                 total_estimated = sum([x.measure for x in estimation.measures])
-                print('Expected: {}'.format(total_expected))
-                print('Estimated: {}'.format(total_estimated))
                 assert total_estimated == total_expected
 
     with context('A 3.1A LB Tariff'):

--- a/spec/profiles/profile_spec.py
+++ b/spec/profiles/profile_spec.py
@@ -414,6 +414,27 @@ with description("When profiling"):
             assert cons['P5'] == 0
             assert cons['P6'] == 0
 
+        with context('And the tariff is RE'):
+            with fit('zero values for sun coefficient should not cause problems '):
+                measures = []
+                di = '2019-01-01 01:00:00'
+                df = '2019-02-01 00:00:00'
+                start = TIMEZONE.localize(datetime.strptime(di, '%Y-%m-%d %H:%M:%S'))
+                end = TIMEZONE.localize(datetime.strptime(df, '%Y-%m-%d %H:%M:%S'))
+                profile = Profile(start, end, measures)
+                profile.profile_class = REProfileZone5
+                tariff = TRE()
+                climatic_zone = 5
+                balance = {
+                    'P0': 0
+                }
+                total_expected = 0
+                estimation = profile.estimate(tariff, balance)
+                total_estimated = sum([x.measure for x in estimation.measures])
+                print('Expected: {}'.format(total_expected))
+                print('Estimated: {}'.format(total_estimated))
+                assert total_estimated == total_expected
+
     with context('A 3.1A LB Tariff'):
         with it('must the initial_balance be different to result balance'):
             kva = 1


### PR DESCRIPTION
## Goals

- The calculation of energy in self-consumption cannot give errors of division by zero.

## New behavior

- If a coefficient is zero, it will be assumed that no energy is generated (gap_energy = 0).

## Checklist

- [x] Test code