### PR TITLE
Added a treatment for 31A6P tariffs when there is energy in P4 period

### DIFF
--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -437,6 +437,9 @@ class Profile(object):
             balance = tariff.apply_31A_LB_cof(
                 balance, self.start_date, self.end_date
             )
+        # Adapt T31A6P adding P4 to P1
+        if isinstance(tariff, T31A) and balance.get('P4', 0) > 0:
+            balance['P1'] += balance['P4']
 
         measures = [x for x in self.measures if x.valid]
         start = self.start_date

--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -440,6 +440,7 @@ class Profile(object):
         # Adapt T31A6P adding P4 to P1
         if isinstance(tariff, T31A) and balance.get('P4', 0) > 0:
             balance['P1'] += balance['P4']
+            balance['P4'] = 0
 
         measures = [x for x in self.measures if x.valid]
         start = self.start_date

--- a/spec/profiles/profile_spec.py
+++ b/spec/profiles/profile_spec.py
@@ -432,6 +432,23 @@ with description("When profiling"):
 
             assert res != initial_balance
 
+    with context('A 3.1A Tariff with 6 periods'):
+        with it('must take into acount P4 in the result balance'):
+            kva = 1
+            tariff = T31A(kva=kva)
+            balance = {
+                'P1': 100,
+                'P2': 80,
+                'P3': 60,
+                'P4': 12,
+                'P5': 15,
+                'P6': 15,
+            }
+            total_expected = sum([x for x in balance.values()])
+            estimation = self.profile.estimate(tariff, balance)
+            total_estimated = sum([x.measure for x in estimation.measures])
+            assert total_estimaded == total_expected
+
 with description('A profile'):
     with before.all:
         measures = []

--- a/spec/profiles/profile_spec.py
+++ b/spec/profiles/profile_spec.py
@@ -434,18 +434,21 @@ with description("When profiling"):
 
     with context('A 3.1A Tariff with 6 periods'):
         with it('must take into account P4 in the result balance'):
-            kva = 1
-            tariff = T31A(kva=kva)
+            measures = []
+            start = TIMEZONE.localize(datetime(2017, 9, 1))
+            end = TIMEZONE.localize(datetime(2017, 9, 5))
+            profile = Profile(start, end, measures)
+            tariff = T31A()
             balance = {
-                'P1': 100,
-                'P2': 80,
-                'P3': 60,
-                'P4': 12,
-                'P5': 15,
-                'P6': 15,
+                'P1': 10,
+                'P2': 10,
+                'P3': 10,
+                'P4': 10,
+                'P5': 10,
+                'P6': 10,
             }
             total_expected = sum([x for x in balance.values()])
-            estimation = self.profile.estimate(tariff, balance)
+            estimation = profile.estimate(tariff, balance)
             total_estimated = sum([x.measure for x in estimation.measures])
             assert total_estimated == total_expected
 

--- a/spec/profiles/profile_spec.py
+++ b/spec/profiles/profile_spec.py
@@ -433,7 +433,7 @@ with description("When profiling"):
             assert res != initial_balance
 
     with context('A 3.1A Tariff with 6 periods'):
-        with it('must take into acount P4 in the result balance'):
+        with it('must take into account P4 in the result balance'):
             kva = 1
             tariff = T31A(kva=kva)
             balance = {
@@ -447,7 +447,7 @@ with description("When profiling"):
             total_expected = sum([x for x in balance.values()])
             estimation = self.profile.estimate(tariff, balance)
             total_estimated = sum([x.measure for x in estimation.measures])
-            assert total_estimaded == total_expected
+            assert total_estimated == total_expected
 
 with description('A profile'):
     with before.all:


### PR DESCRIPTION
## Goals

- The profiling must be carried out correctly in cases where there is energy in the P4.

## New behavior

- If there is energy in P4, it is added to P1 so that it is profiled correctly.

## Relacionado

Closes #121

## Checklist

- [x] Test code
