### PR TITLE
Translate civil hour to solar hour in RE

### DIFF
--- a/enerdata/datetime/solar_hour.py
+++ b/enerdata/datetime/solar_hour.py
@@ -3,18 +3,16 @@ from enerdata.datetime.timezone import TIMEZONE
 from pytz import utc
 
 
-def convert_to_solar_hour(civil_hour=False):
+def convert_to_solar_hour(civil_hour):
     """
     Convert datetime to equivalent datetime solar hour
-    :param civil_hour: datetime
+    :param civil_hour: datetimed
     :return: datetime equivalent solar hour
     """
-    if not civil_hour:
-        civil_hour = datetime.now()
     if not isinstance(civil_hour, datetime):
         raise ValueError('datetime was expected, found {}'.format(civil_hour))
     if not civil_hour.tzinfo:
-        civil_hour = TIMEZONE.localize(civil_hour, is_dst=True)  # daylight saving time
+        raise ValueError('datetime must be located: {}'.format(civil_hour))
     solar_hour = civil_hour.astimezone(utc)
 
     return solar_hour

--- a/enerdata/datetime/solar_hour.py
+++ b/enerdata/datetime/solar_hour.py
@@ -14,8 +14,7 @@ def convert_to_solar_hour(civil_hour=False):
     if not isinstance(civil_hour, datetime):
         raise ValueError('% datetime was expected' % civil_hour)
     if not civil_hour.tzinfo:
-        solar_hour = TIMEZONE.localize(civil_hour, is_dst=True)  # daylight saving time
-    else:
-        solar_hour = civil_hour.astimezone(utc)
+        civil_hour = TIMEZONE.localize(civil_hour, is_dst=True)  # daylight saving time
+    solar_hour = civil_hour.astimezone(utc)
 
     return solar_hour

--- a/enerdata/datetime/solar_hour.py
+++ b/enerdata/datetime/solar_hour.py
@@ -12,8 +12,10 @@ def convert_to_solar_hour(civil_hour=False):
     if not civil_hour:
         civil_hour = datetime.now()
     if not isinstance(civil_hour, datetime):
-        raise ValueError('% date is not a datetime' % civil_hour)
-    solar_hour = TIMEZONE.localize(civil_hour, is_dst=True)  # No daylight saving time
-    solar_hour = solar_hour.astimezone(utc)
+        raise ValueError('% datetime was expected' % civil_hour)
+    if not civil_hour.tzinfo:
+        solar_hour = TIMEZONE.localize(civil_hour, is_dst=True)  # daylight saving time
+    else:
+        solar_hour = civil_hour.astimezone(utc)
 
     return solar_hour

--- a/enerdata/datetime/solar_hour.py
+++ b/enerdata/datetime/solar_hour.py
@@ -12,7 +12,7 @@ def convert_to_solar_hour(civil_hour=False):
     if not civil_hour:
         civil_hour = datetime.now()
     if not isinstance(civil_hour, datetime):
-        raise ValueError('% datetime was expected' % civil_hour)
+        raise ValueError('datetime was expected, found {}'.format(civil_hour))
     if not civil_hour.tzinfo:
         civil_hour = TIMEZONE.localize(civil_hour, is_dst=True)  # daylight saving time
     solar_hour = civil_hour.astimezone(utc)

--- a/enerdata/datetime/solar_hour.py
+++ b/enerdata/datetime/solar_hour.py
@@ -1,0 +1,19 @@
+from enerdata.datetime import datetime
+from enerdata.datetime.timezone import TIMEZONE
+from pytz import utc
+
+
+def convert_to_solar_hour(civil_hour=False):
+    """
+    Convert datetime to equivalent datetime solar hour
+    :param civil_hour: datetime
+    :return: datetime equivalent solar hour
+    """
+    if not civil_hour:
+        civil_hour = datetime.now()
+    if not isinstance(civil_hour, datetime):
+        raise ValueError('% date is not a datetime' % civil_hour)
+    solar_hour = TIMEZONE.localize(civil_hour, is_dst=True)  # No daylight saving time
+    solar_hour = solar_hour.astimezone(utc)
+
+    return solar_hour

--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -282,9 +282,9 @@ class REProfile(object):
         cofs = []
         while start <= end:
             month = self.translate_month[start.month]
-            dt = convert_to_solar_hour(start)
-            if dt.hour != 0:
-                hour = dt.hour
+            solar_hour = convert_to_solar_hour(start)
+            if solar_hour.hour != 0:
+                hour = solar_hour.hour
             else:
                 hour = 24
             coff_value = float(df[df[key] == month][hour])

--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -19,6 +19,7 @@ from enerdata.datetime.timezone import TIMEZONE
 from enerdata.metering.measure import Measure, EnergyMeasure
 from enerdata.datetime.holidays import get_holidays
 from enerdata.datetime.work_and_holidays import get_num_of_workdays_holidays
+from enerdata.datetime.solar_hour import convert_to_solar_hour
 
 from os import path
 import pandas as pd

--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -281,6 +281,7 @@ class REProfile(object):
         cofs = []
         while start <= end:
             month = self.translate_month[start.month]
+            start = convert_to_solar_hour(start)
             if start.hour != 0:
                 hour = start.hour
             else:

--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -282,9 +282,9 @@ class REProfile(object):
         cofs = []
         while start <= end:
             month = self.translate_month[start.month]
-            start = convert_to_solar_hour(start)
-            if start.hour != 0:
-                hour = start.hour
+            dt = convert_to_solar_hour(start)
+            if dt.hour != 0:
+                hour = dt.hour
             else:
                 hour = 24
             coff_value = float(df[df[key] == month][hour])

--- a/spec/datetime/solar_hour_spec.py
+++ b/spec/datetime/solar_hour_spec.py
@@ -1,13 +1,39 @@
-from datetime import datetime
+from enerdata.datetime import datetime
+from enerdata.datetime.station import get_station
 from enerdata.datetime.solar_hour import convert_to_solar_hour
+from enerdata.datetime.timezone import TIMEZONE
 from dateutil.relativedelta import relativedelta
+from expects import expect, equal
 
-with description("The civil hour"):
-    with it("it's two hours more than solar"):
-        dt = datetime.now()
-        final_dt = dt + relativedelta(years=25)
-        while dt < final_dt:
-            dt = dt + relativedelta(days=1)
-            res = convert_to_solar_hour(dt)
-            assert dt != res
+DIFFERENCE_HOURS = {'summer': 2, 'winter': 1}
 
+with description("The solar hour"):
+
+    with context("in Summer"):
+        with it("is the civil time plus 2"):
+            dt = TIMEZONE.localize(datetime(2019, 4, 1, 1))
+            final_dt = dt + relativedelta(months=3)
+            hours = DIFFERENCE_HOURS['summer']
+            while dt < final_dt:
+                dt = dt + relativedelta(hours=1)
+                solar_hour = convert_to_solar_hour(dt)
+                civil_hour_to_expect = dt - relativedelta(hours=hours)
+                assert civil_hour_to_expect.hour == solar_hour.hour
+        with it("is the civil time plus 1"):
+            dt = TIMEZONE.localize(datetime(2019, 11, 1, 1))
+            final_dt = dt + relativedelta(months=3)
+            hours = DIFFERENCE_HOURS['winter']
+            while dt < final_dt:
+                dt = dt + relativedelta(hours=1)
+                solar_hour = convert_to_solar_hour(dt)
+                civil_hour_to_expect = dt - relativedelta(hours=hours)
+                assert civil_hour_to_expect.hour == solar_hour.hour
+
+    with context("when it's random"):
+        with it("must meet the difference of hours with the civil"):
+            dtc = TIMEZONE.localize(datetime.now())
+            station = get_station(dtc)
+            hours = DIFFERENCE_HOURS[station]
+            solar_hour = convert_to_solar_hour(dtc)
+            civil_hour_to_expect = dtc - relativedelta(hours=hours)
+            expect(civil_hour_to_expect.hour).to(equal(solar_hour.hour))

--- a/spec/datetime/solar_hour_spec.py
+++ b/spec/datetime/solar_hour_spec.py
@@ -43,3 +43,8 @@ with description("The solar hour"):
             dt = TIMEZONE.localize(datetime(2019, 11, 1, 1))
             dt = convert_to_solar_hour(dt)
             expect(dt.tzname()).to(start_with('UTC'))
+
+    with context("calculated correctly"):
+        with it("when civil hour not specified"):
+            dt = convert_to_solar_hour()
+            assert isinstance(dt, datetime)

--- a/spec/datetime/solar_hour_spec.py
+++ b/spec/datetime/solar_hour_spec.py
@@ -3,7 +3,7 @@ from enerdata.datetime.station import get_station
 from enerdata.datetime.solar_hour import convert_to_solar_hour
 from enerdata.datetime.timezone import TIMEZONE
 from dateutil.relativedelta import relativedelta
-from expects import expect, equal, start_with
+from expects import expect, equal, start_with, raise_error
 
 DIFFERENCE_HOURS = {'summer': 2, 'winter': 1}
 
@@ -48,3 +48,10 @@ with description("The solar hour"):
         with it("when civil hour not specified"):
             dt = convert_to_solar_hour()
             assert isinstance(dt, datetime)
+
+    with context("raise an error"):
+        with it("when civil hour is not datetime"):
+            def get_convert_to_solar_hour_error():
+                str_dt = '2019-01-01'
+                convert_to_solar_hour(str_dt)
+            expect(get_convert_to_solar_hour_error).to(raise_error(ValueError))

--- a/spec/datetime/solar_hour_spec.py
+++ b/spec/datetime/solar_hour_spec.py
@@ -3,7 +3,7 @@ from enerdata.datetime.station import get_station
 from enerdata.datetime.solar_hour import convert_to_solar_hour
 from enerdata.datetime.timezone import TIMEZONE
 from dateutil.relativedelta import relativedelta
-from expects import expect, equal
+from expects import expect, equal, start_with
 
 DIFFERENCE_HOURS = {'summer': 2, 'winter': 1}
 
@@ -37,3 +37,9 @@ with description("The solar hour"):
             solar_hour = convert_to_solar_hour(dtc)
             civil_hour_to_expect = dtc - relativedelta(hours=hours)
             expect(civil_hour_to_expect.hour).to(equal(solar_hour.hour))
+
+    with context("must be located"):
+        with it("even if the civil hour is not"):
+            dt = TIMEZONE.localize(datetime(2019, 11, 1, 1))
+            dt = convert_to_solar_hour(dt)
+            expect(dt.tzname()).to(start_with('UTC'))

--- a/spec/datetime/solar_hour_spec.py
+++ b/spec/datetime/solar_hour_spec.py
@@ -1,4 +1,4 @@
-from enerdata.datetime import datetime
+from datetime import datetime
 from enerdata.datetime.solar_hour import convert_to_solar_hour
 from dateutil.relativedelta import relativedelta
 

--- a/spec/datetime/solar_hour_spec.py
+++ b/spec/datetime/solar_hour_spec.py
@@ -3,7 +3,7 @@ from enerdata.datetime.station import get_station
 from enerdata.datetime.solar_hour import convert_to_solar_hour
 from enerdata.datetime.timezone import TIMEZONE
 from dateutil.relativedelta import relativedelta
-from expects import expect, equal, start_with, raise_error
+from expects import expect, equal, raise_error
 
 DIFFERENCE_HOURS = {'summer': 2, 'winter': 1}
 
@@ -38,16 +38,12 @@ with description("The solar hour"):
             civil_hour_to_expect = dtc - relativedelta(hours=hours)
             expect(civil_hour_to_expect.hour).to(equal(solar_hour.hour))
 
-    with context("must be located"):
-        with it("even if the civil hour is not"):
-            dt = TIMEZONE.localize(datetime(2019, 11, 1, 1))
-            dt = convert_to_solar_hour(dt)
-            expect(dt.tzname()).to(start_with('UTC'))
-
-    with context("calculated correctly"):
-        with it("when civil hour not specified"):
-            dt = convert_to_solar_hour()
-            assert isinstance(dt, datetime)
+    with context("raise an error"):
+        with it("when civil hour is not located"):
+            def get_convert_to_solar_hour_error():
+                dt = datetime.now()
+                convert_to_solar_hour(dt)
+            expect(get_convert_to_solar_hour_error).to(raise_error(ValueError))
 
     with context("raise an error"):
         with it("when civil hour is not datetime"):

--- a/spec/datetime/solar_hour_spec.py
+++ b/spec/datetime/solar_hour_spec.py
@@ -1,0 +1,13 @@
+from enerdata.datetime import datetime
+from enerdata.datetime.solar_hour import convert_to_solar_hour
+from dateutil.relativedelta import relativedelta
+
+with description("The civil hour"):
+    with it("it's two hours more than solar"):
+        dt = datetime.now()
+        final_dt = dt + relativedelta(years=25)
+        while dt < final_dt:
+            dt = dt + relativedelta(days=1)
+            res = convert_to_solar_hour(dt)
+            assert dt != res
+

--- a/spec/datetime/station_spec.py
+++ b/spec/datetime/station_spec.py
@@ -12,13 +12,3 @@ with description('The station module'):
         assert get_station(datetime(2014, 10, 26, 2)) == 'winter'
         assert get_station(datetime(2014, 3, 30, 2)) == 'summer'
         assert get_station(TIMEZONE.localize(datetime(2014, 10, 26, 2), is_dst=True)) == 'summer'
-
-with description("The civil hour"):
-    with it("it's two hours more than solar"):
-        dt = datetime.now()
-        final_dt = dt + relativedelta(years=2)
-        while dt < final_dt:
-            civil_hour = dt
-            solar_hour = TIMEZONE.localize(civil_hour, is_dst=True) # No daylight saving time
-            solar_hour = solar_hour.astimezone(utc)
-        assert solar_hour == civil_hour

--- a/spec/datetime/station_spec.py
+++ b/spec/datetime/station_spec.py
@@ -1,5 +1,7 @@
 from enerdata.datetime import datetime
 from enerdata.datetime.timezone import TIMEZONE
+from pytz import utc
+from dateutil import relativedelta
 from enerdata.datetime.station import *
 
 
@@ -10,3 +12,13 @@ with description('The station module'):
         assert get_station(datetime(2014, 10, 26, 2)) == 'winter'
         assert get_station(datetime(2014, 3, 30, 2)) == 'summer'
         assert get_station(TIMEZONE.localize(datetime(2014, 10, 26, 2), is_dst=True)) == 'summer'
+
+with description("The civil hour"):
+    with it("it's two hours more than solar"):
+        dt = datetime.now()
+        final_dt = dt + relativedelta(years=2)
+        while dt < final_dt:
+            civil_hour = dt
+            solar_hour = TIMEZONE.localize(civil_hour, is_dst=True) # No daylight saving time
+            solar_hour = solar_hour.astimezone(utc)
+        assert solar_hour == civil_hour

--- a/spec/datetime/station_spec.py
+++ b/spec/datetime/station_spec.py
@@ -1,7 +1,5 @@
 from enerdata.datetime import datetime
 from enerdata.datetime.timezone import TIMEZONE
-from pytz import utc
-from dateutil import relativedelta
 from enerdata.datetime.station import *
 
 


### PR DESCRIPTION
From #117 
Closes #117 

In RE profiling, the coefficients are indicated in solar hours, they must be translated at civil hours according to:

Los valores de las horas que aparecen en las tablas siguientes corresponden al tiempo solar. En el horario de invierno la hora civil corresponde a la hora solar más 1 unidad, y en el horario de verano la hora civil corresponde a la hora solar más 2 unidades. Los cambios de horario de invierno a verano o viceversa coincidirán con la fecha de cambio oficial de hora.

Is the first hour of the month corresponding to the last solar hour of the previous month?
> It is not a problem since the initial and final hours of the day of each month of each climatic zone are without sun, so coefficient = 0