### PR TITLE
workalendar<8.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytz
-workalendar
+workalendar<8.0.0
 pandas
 xlrd


### PR DESCRIPTION
Limitar rquerimiento de la libreria workalendar para mantener compatibilidad con python 2.7
workalendar<8.0.0