### PR TITLE
Fix include csv files in packages setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import sys
 from setuptools import setup, find_packages
 
-PACKAGES_DATA = {'enerdata': ['profiles/data/*.xlsx']}
+PACKAGES_DATA = {'enerdata': ['profiles/data/*.xlsx', 'profiles/data/*.csv']}
 
 INSTALL_REQUIRES = ['pytz', 'workalendar<8.0.0']
 


### PR DESCRIPTION
If installed version via `pip install enerdata`, data csv are not included in the package