### PR TITLE
Fix pandas to v0.23.4 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytz
 workalendar<8.0.0
-pandas
+pandas==0.23.4
 xlrd


### PR DESCRIPTION
Fix pandas to v0.23.4 version to avoid a newer not compatible API