### PR TITLE
Fix curve with losses

### DIFF
--- a/enerdata/__init__.py
+++ b/enerdata/__init__.py
@@ -1,1 +1,2 @@
 __author__ = 'ecarreras'
+__version__ = '0.24.0-rc.1'

--- a/enerdata/__init__.py
+++ b/enerdata/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'ecarreras'
-__version__ = '0.24.0-rc.1'
+__version__ = '0.24.0-rc.2'

--- a/enerdata/contracts/tariff.py
+++ b/enerdata/contracts/tariff.py
@@ -482,8 +482,17 @@ class T31A(T30A):
             consumptions[period] = round(
                 consumption * (1 + self.losses), 2
             ) + round(0.01 * cofs[period] * self.kva, 2)
-
         return consumptions
+
+    def apply_curve_losses(self, measures, kva):
+        from enerdata.profiles import Dragger
+        dragger = Dragger()
+        for idx, measure in enumerate(measures):
+            values = measure._asdict()
+            consumption = dragger.drag(round(measure.measure * (1 + self.losses), 2) + round(0.01 * kva, 2))
+            values['measure'] = consumption
+            measures[idx] = measure._replace(**values)
+        return measures
 
     def evaluate_powers(self, powers):
         super(T31A, self).evaluate_powers(powers)

--- a/enerdata/contracts/tariff.py
+++ b/enerdata/contracts/tariff.py
@@ -485,11 +485,9 @@ class T31A(T30A):
         return consumptions
 
     def apply_curve_losses(self, measures):
-        from enerdata.profiles import Dragger
-        dragger = Dragger()
         for idx, measure in enumerate(measures):
             values = measure._asdict()
-            consumption = dragger.drag(round(measure.measure * (1 + self.losses), 2) + round(0.01 * self.kva, 2))
+            consumption = round(measure.measure * (1 + self.losses), 2) + round(0.01 * self.kva, 2)
             values['measure'] = consumption
             measures[idx] = measure._replace(**values)
         return measures

--- a/enerdata/contracts/tariff.py
+++ b/enerdata/contracts/tariff.py
@@ -484,12 +484,12 @@ class T31A(T30A):
             ) + round(0.01 * cofs[period] * self.kva, 2)
         return consumptions
 
-    def apply_curve_losses(self, measures, kva):
+    def apply_curve_losses(self, measures):
         from enerdata.profiles import Dragger
         dragger = Dragger()
         for idx, measure in enumerate(measures):
             values = measure._asdict()
-            consumption = dragger.drag(round(measure.measure * (1 + self.losses), 2) + round(0.01 * kva, 2))
+            consumption = dragger.drag(round(measure.measure * (1 + self.losses), 2) + round(0.01 * self.kva, 2))
             values['measure'] = consumption
             measures[idx] = measure._replace(**values)
         return measures

--- a/enerdata/contracts/tariff.py
+++ b/enerdata/contracts/tariff.py
@@ -482,6 +482,7 @@ class T31A(T30A):
             consumptions[period] = round(
                 consumption * (1 + self.losses), 2
             ) + round(0.01 * cofs[period] * self.kva, 2)
+
         return consumptions
 
     def apply_curve_losses(self, measures):

--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -493,11 +493,6 @@ class Profile(object):
             balance = {
                 "P1": sum([values for values in balance.values()])
             }
-        # Get balance for T31ALB
-        if isinstance(tariff, T31A) and tariff.low_voltage_measure:
-            balance = tariff.apply_31A_LB_cof(
-                balance, self.start_date, self.end_date
-            )
         # Adapt T31A6P adding P4 to P1
         if isinstance(tariff, T31A) and balance.get('P4', 0) > 0:
             balance['P1'] += balance['P4']
@@ -611,6 +606,9 @@ class Profile(object):
         profile = self.estimate(tariff, balance)
         # Adjust to the balance
         profile = profile.adjust(tariff, balance, diff)
+
+        if isinstance(tariff, T31A) and tariff.low_voltage_measure:
+            profile.measures = tariff.apply_curve_losses(profile.measures)
         return profile
 
     def __repr__(self):

--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -619,6 +619,12 @@ class Profile(object):
 
         if isinstance(tariff, T31A) and tariff.low_voltage_measure:
             profile.measures = tariff.apply_curve_losses(profile.measures)
+            # Drag curve losses to set measure without decimals
+            dragger_consumption = Dragger()
+            for idx, measure in enumerate(profile.measures):
+                values = measure._asdict()
+                consumption = dragger_consumption.drag(measure.measure)
+                profile.measures[idx] = measure._replace(**values)
         return profile
 
     def __repr__(self):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if sys.version_info < (2, 7):
 
 setup(
     name='enerdata',
-    version='0.23.1',
+    version='0.24.0-rc.1',
     packages=find_packages(),
     url='http://code.gisce.net',
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import sys
 from setuptools import setup, find_packages
+from enerdata import __version__
 
 PACKAGES_DATA = {'enerdata': ['profiles/data/*.xlsx', 'profiles/data/*.csv']}
 
@@ -10,7 +11,7 @@ if sys.version_info < (2, 7):
 
 setup(
     name='enerdata',
-    version='0.24.0-rc.1',
+    version=__version__,
     packages=find_packages(),
     url='http://code.gisce.net',
     license='MIT',

--- a/spec/profiles/profile_spec.py
+++ b/spec/profiles/profile_spec.py
@@ -700,7 +700,7 @@ with description("An estimation"):
             assert total_expected == total_estimated, "For tariff '{}' Total energy '{}' must match the expected '{}'".format(a_tariff["tariff"], total_estimated, total_expected)
 
     with context("a Tariff with losses"):
-        with fit("doesn't must apply the penalty"):
+        with it("doesn't must apply the penalty"):
             fake_contract = {
                 'start': TIMEZONE.localize(datetime(2017, 11, 1, 1, 0, 0)),
                 'end': TIMEZONE.localize(datetime(2017, 12, 1, 0, 0, 0)),


### PR DESCRIPTION
Fix draft existent curve with applying losses.
Cases:
- Real and complete curve
- Curve with gaps
- Inexistent curve (estimate)
- Refix curve cannot duplicate the consumption losses

Todo:
- [x] Include apply_losses of end method `fixit`
- [x] Del apply losses on method `estimate`
- [x] Change signature of method `apply_losses` omitting `kva` value

Usabillity code integration:
- The fixit will also be used
- To apply losses, the rate must be instantiated as:`T31ALB(kva)`
- To apply losses on `estimate` method, just type: `tariff.apply_curve_losses(curve)`