### PR TITLE
Añadir funcion para evaluar todas las validaciones de tarifa y acomular errores en el retorno

### DIFF
--- a/enerdata/contracts/tariff.py
+++ b/enerdata/contracts/tariff.py
@@ -142,7 +142,7 @@ class Tariff(object):
 
         return True
 
-    def evaluate_powers(self, powers):
+    def evaluate_powers(self, powers, allow_only_1_min_period=False):
         if min(powers) <= 0:
             raise NotPositivePower()
         if not len(self.power_periods) == len(powers):
@@ -150,7 +150,8 @@ class Tariff(object):
         if not self.is_maximum_power_correct(max(powers)):
             raise IncorrectMaxPower(max(powers), self.min_power, self.max_power)
         if not self.is_minimum_powers_correct(min(powers)):
-            raise IncorrectMinPower(min(powers), self.min_power, self.max_power)
+            if not (allow_only_1_min_period and self.is_minimum_powers_correct(max(powers))):
+                raise IncorrectMinPower(min(powers), self.min_power, self.max_power)
         if not self.are_powers_normalized(powers):
             raise NotNormalizedPower()
 
@@ -485,8 +486,8 @@ class T31A(T30A):
 
         return consumptions
 
-    def evaluate_powers(self, powers):
-        super(T31A, self).evaluate_powers(powers)
+    def evaluate_powers(self, powers, allow_only_1_min_period=False):
+        super(T31A, self).evaluate_powers(powers, allow_only_1_min_period)
 
         if not are_powers_ascending(powers):
             raise NotAscendingPowers()
@@ -583,8 +584,8 @@ class T61A(Tariff):
         # 6.1A doesn't need to have normalized powers
         return True
 
-    def evaluate_powers(self, powers):
-        super(T61A, self).evaluate_powers(powers)
+    def evaluate_powers(self, powers, allow_only_1_min_period=False):
+        super(T61A, self).evaluate_powers(powers, allow_only_1_min_period)
 
         if not are_powers_ascending(powers):
             raise NotAscendingPowers()

--- a/enerdata/contracts/tariff.py
+++ b/enerdata/contracts/tariff.py
@@ -142,7 +142,28 @@ class Tariff(object):
 
         return True
 
-    def evaluate_powers(self, powers, allow_only_1_min_period=False):
+    def evaluate_powers_all_checks(self, powers):
+        """
+
+        :param powers: [pow1, pow2,...]
+        :return: [Error1, Error2] if errors else []
+        """
+        errors = []
+        if min(powers) <= 0:
+            errors.append(NotPositivePower())
+        if not len(self.power_periods) == len(powers):
+            errors.append(IncorrectPowerNumber(len(powers), len(self.power_periods)))
+        if not self.is_maximum_power_correct(max(powers)):
+            errors.append(IncorrectMaxPower(max(powers), self.min_power, self.max_power))
+        if not self.is_minimum_powers_correct(min(powers)):
+            errors.append(IncorrectMinPower(min(powers), self.min_power, self.max_power))
+        if not self.are_powers_normalized(powers):
+            errors.append(NotNormalizedPower())
+
+        return errors
+
+
+    def evaluate_powers(self, powers):
         if min(powers) <= 0:
             raise NotPositivePower()
         if not len(self.power_periods) == len(powers):
@@ -150,8 +171,7 @@ class Tariff(object):
         if not self.is_maximum_power_correct(max(powers)):
             raise IncorrectMaxPower(max(powers), self.min_power, self.max_power)
         if not self.is_minimum_powers_correct(min(powers)):
-            if not (allow_only_1_min_period and self.is_minimum_powers_correct(max(powers))):
-                raise IncorrectMinPower(min(powers), self.min_power, self.max_power)
+            raise IncorrectMinPower(min(powers), self.min_power, self.max_power)
         if not self.are_powers_normalized(powers):
             raise NotNormalizedPower()
 
@@ -486,8 +506,8 @@ class T31A(T30A):
 
         return consumptions
 
-    def evaluate_powers(self, powers, allow_only_1_min_period=False):
-        super(T31A, self).evaluate_powers(powers, allow_only_1_min_period)
+    def evaluate_powers(self, powers):
+        super(T31A, self).evaluate_powers(powers)
 
         if not are_powers_ascending(powers):
             raise NotAscendingPowers()
@@ -585,7 +605,7 @@ class T61A(Tariff):
         return True
 
     def evaluate_powers(self, powers, allow_only_1_min_period=False):
-        super(T61A, self).evaluate_powers(powers, allow_only_1_min_period)
+        super(T61A, self).evaluate_powers(powers)
 
         if not are_powers_ascending(powers):
             raise NotAscendingPowers()

--- a/enerdata/contracts/tariff.py
+++ b/enerdata/contracts/tariff.py
@@ -603,7 +603,7 @@ class T61A(Tariff):
         # 6.1A doesn't need to have normalized powers
         return True
 
-    def evaluate_powers(self, powers, allow_only_1_min_period=False):
+    def evaluate_powers(self, powers):
         super(T61A, self).evaluate_powers(powers)
 
         if not are_powers_ascending(powers):

--- a/enerdata/contracts/tariff.py
+++ b/enerdata/contracts/tariff.py
@@ -162,7 +162,6 @@ class Tariff(object):
 
         return errors
 
-
     def evaluate_powers(self, powers):
         if min(powers) <= 0:
             raise NotPositivePower()

--- a/enerdata/contracts/tariff.py
+++ b/enerdata/contracts/tariff.py
@@ -513,6 +513,13 @@ class T31A(T30A):
 
         return True
 
+    def evaluate_powers_all_checks(self, powers):
+        errors = super(T31A, self).evaluate_powers_all_checks(powers)
+        if not are_powers_ascending(powers):
+            errors.append(NotAscendingPowers())
+
+        return errors
+
 
 class T31A_one_period(T31A):
     """
@@ -610,6 +617,13 @@ class T61A(Tariff):
             raise NotAscendingPowers()
 
         return True
+
+    def evaluate_powers_all_checks(self, powers):
+        errors = super(T61A, self).evaluate_powers_all_checks(powers)
+        if not are_powers_ascending(powers):
+            errors.append(NotAscendingPowers())
+
+        return errors
 
 
 class T61B(T61A):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytz
 workalendar<8.0.0
 pandas==0.23.4
-xlrd>=1.2.0
+xlrd==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytz
 workalendar<8.0.0
 pandas==0.23.4
-xlrd
+xlrd>=1.2.0

--- a/spec/contracts/tariff_spec.py
+++ b/spec/contracts/tariff_spec.py
@@ -149,6 +149,9 @@ with context('A tariff'):
             raise_error(NotNormalizedPower))
         expect(lambda: tari_T30A.evaluate_powers([14, 15.242, 15.242])).to(
             raise_error(IncorrectMinPower))
+        expect(lambda: tari_T30A.evaluate_powers([14, 14.242, 14.342], True)).to(
+            raise_error(IncorrectMinPower))
+        assert tari_T30A.evaluate_powers([14, 14.242, 15.242], True)
         assert tari_T30A.evaluate_powers([15.242, 15.242, 16.454])
         expect(lambda: tari_T30A.evaluate_powers([16, 17])).to(
             raise_error(IncorrectPowerNumber, 'Expected 3 power(s) and got 2'))

--- a/spec/contracts/tariff_spec.py
+++ b/spec/contracts/tariff_spec.py
@@ -149,9 +149,6 @@ with context('A tariff'):
             raise_error(NotNormalizedPower))
         expect(lambda: tari_T30A.evaluate_powers([14, 15.242, 15.242])).to(
             raise_error(IncorrectMinPower))
-        expect(lambda: tari_T30A.evaluate_powers([14, 14.242, 14.342], True)).to(
-            raise_error(IncorrectMinPower))
-        assert tari_T30A.evaluate_powers([14, 14.242, 15.242], True)
         assert tari_T30A.evaluate_powers([15.242, 15.242, 16.454])
         expect(lambda: tari_T30A.evaluate_powers([16, 17])).to(
             raise_error(IncorrectPowerNumber, 'Expected 3 power(s) and got 2'))

--- a/spec/contracts/tariff_spec.py
+++ b/spec/contracts/tariff_spec.py
@@ -221,6 +221,34 @@ with context('A tariff'):
             lambda: tari_T64.evaluate_powers([500, 600, 700, 700, 600, 500])
         ).to(
             raise_error(NotAscendingPowers))
+    with it('should allow to check if a set of powers is correct'):
+        tari_T20A = T20A()
+        assert len(tari_T20A.evaluate_powers_all_checks([-10]))
+        assert len(tari_T20A.evaluate_powers_all_checks([0]))
+        assert len(tari_T20A.evaluate_powers_all_checks([5.55])) == 0
+        assert len(tari_T20A.evaluate_powers_all_checks([5, 7]))
+        assert len(tari_T20A.evaluate_powers_all_checks([100]))
+
+        tari_T30A = T30A()
+        assert len(tari_T30A.evaluate_powers_all_checks([-10, -5, 0]))
+        assert len(tari_T30A.evaluate_powers_all_checks([15, 15, 15]))
+        assert len(tari_T30A.evaluate_powers_all_checks([16, 17.1, 16]))
+        assert len(tari_T30A.evaluate_powers_all_checks([14, 15.242, 15.242]))
+        assert len(tari_T30A.evaluate_powers_all_checks([15.242, 15.242, 16.454])) == 0
+        assert len(tari_T30A.evaluate_powers_all_checks([16, 17]))
+
+        tari_T31A = T31A()
+        assert len(tari_T31A.evaluate_powers_all_checks([-10, -5, 0]))
+        assert len(tari_T31A.evaluate_powers_all_checks([10, 13, 16])) == 0
+        assert len(tari_T31A.evaluate_powers_all_checks([16, 17]))
+        assert len(tari_T31A.evaluate_powers_all_checks([16, 20, 16]))
+
+        tari_T61A = T61A()
+        assert len(tari_T61A.evaluate_powers_all_checks([-10, -5, 0, 10, 20]))
+        assert len(tari_T61A.evaluate_powers_all_checks([400, 410, 420, 430, 440, 451])) == 0
+        assert len(tari_T61A.evaluate_powers_all_checks([500, 600, 700, 800, 900, 1000])) == 0
+        assert len(tari_T61A.evaluate_powers_all_checks([16, 17]))
+        assert len(tari_T61A.evaluate_powers_all_checks([500, 600, 700, 700, 600, 500]))
 
     with it('shouldn\'t fail due to bad rounding'):
         tari_T20A = T20A()

--- a/spec/contracts/tariff_spec.py
+++ b/spec/contracts/tariff_spec.py
@@ -225,7 +225,7 @@ with context('A tariff'):
         tari_T20A = T20A()
         assert len(tari_T20A.evaluate_powers_all_checks([-10]))
         assert len(tari_T20A.evaluate_powers_all_checks([0]))
-        assert len(tari_T20A.evaluate_powers_all_checks([5.55])) == 0
+        assert len(tari_T20A.evaluate_powers_all_checks([3.5])) == 0
         assert len(tari_T20A.evaluate_powers_all_checks([5, 7]))
         assert len(tari_T20A.evaluate_powers_all_checks([100]))
 


### PR DESCRIPTION
Se añade la funcion `def evaluate_powers_all_checks`, similar a `def evaluate_powers` con la diferencia que esta devuelve un listado de los errores (comprueva todas las validaciones)