### PR TITLE
3.1A LB profiling now works if consumption is zero

### DIFF
--- a/enerdata/contracts/tariff.py
+++ b/enerdata/contracts/tariff.py
@@ -479,9 +479,9 @@ class T31A(T30A):
             else:
                 cofs[period] = period_hours.get(period, 0) * workdays
         for period, consumption in balance.items():
-            consumptions[period] = round(
-                consumption * (1 + self.losses), 2
-            ) + round(0.01 * cofs[period] * self.kva, 2)
+            consumptions[period] = round(consumption * (1 + self.losses), 2)
+            if consumptions[period] > 0.0:
+                consumptions[period] += round(0.01 * cofs[period] * self.kva, 2)
 
         return consumptions
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytz
 workalendar<8.0.0
 pandas==0.23.4
-xlrd
+xlrd==1.0.0


### PR DESCRIPTION
- The casuistry of profiling a curve from the billings when consumption is zero in a 3.1A LB tariff has been corrected. 