### PR TITLE
Perfilador universal de 1 período de energía y correcciones en la obtención de perfiles para PVPC

### DIFF
--- a/enerdata/contracts/tariff.py
+++ b/enerdata/contracts/tariff.py
@@ -1129,6 +1129,17 @@ class T61TDVE(T61TD):
         self.code = '6.1TDVE'
 
 
+class T1P(Tariff):
+    def __init__(self):
+        super(T1P, self).__init__()
+        self.code = '1P'
+        self.cof = '2.0TD'
+        self.periods = (
+            TariffPeriod('P1', 'te'),
+            TariffPeriod('P1', 'tp')
+        )
+
+
 class NotPositivePower(Exception):
     def __init__(self):
         super(NotPositivePower, self).__init__(
@@ -1209,6 +1220,7 @@ def get_tariff_by_code(code):
         '6.3': T63,
         '6.4': T64,
         'RE': TRE,
+        '1P': T1P,
         # New access tariffs 2021
         '2.0TD': T20TD,
         '3.0TD': T30TD,

--- a/enerdata/contracts/tariff.py
+++ b/enerdata/contracts/tariff.py
@@ -1085,7 +1085,7 @@ class T61TD(T30TD):
     def __init__(self, **kwargs):
         super(T61TD, self).__init__(**kwargs)
         self.code = '6.1TD'
-        self.cof = '6.1TD'
+        self.cof = '3.0TD'
         self.min_power = 0
         self.max_power = 100000
         self.require_summer_winter_hours = False

--- a/enerdata/contracts/tariff.py
+++ b/enerdata/contracts/tariff.py
@@ -1085,7 +1085,7 @@ class T61TD(T30TD):
     def __init__(self, **kwargs):
         super(T61TD, self).__init__(**kwargs)
         self.code = '6.1TD'
-        self.cof = '3.0TD'
+        self.cof = None
         self.min_power = 0
         self.max_power = 100000
         self.require_summer_winter_hours = False

--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -252,7 +252,7 @@ class REEProfile(object):
                     n_hour += 1
                     cofs.append(Coefficent(
                         TIMEZONE.normalize(day), dict(
-                            (k, float(vals[i])) for i, k in enumerate(['A', 'B', 'C', 'D', '20TD', '30TD', '30TDVE'], 5)
+                            (k, float(vals[i])) for i, k in enumerate(['A', 'B', 'C', 'D', '2.0TD', '3.0TD', '3.0TDVE'], 5)
                         ))
                     )
                 cls._CACHE[key] = cofs

--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -27,6 +27,19 @@ import pandas as pd
 logger = logging.getLogger(__name__)
 
 
+COEFFS = ['A', 'B', 'C', 'D']
+EXTRA_COEFFS = ['2.0TD', '3.0TD', '3.0TDVE']
+
+
+def get_tariff_coeffs_list(year, month):
+    assert isinstance(year, int)
+    assert isinstance(month, int)
+    if year >= 2021 and month >= 6:
+        return COEFFS + EXTRA_COEFFS
+    else:
+        return COEFFS
+
+
 class Coefficent(namedtuple('Coefficient', ['hour', 'cof'])):
     __slots__ = ()
 
@@ -238,6 +251,7 @@ class REEProfile(object):
                 reader = csv.reader(m, delimiter=';')
                 header = True
                 cofs = []
+                coeffs_list = get_tariff_coeffs_list(year, month)
                 for vals in reader:
                     if header:
                         header = False
@@ -252,7 +266,7 @@ class REEProfile(object):
                     n_hour += 1
                     cofs.append(Coefficent(
                         TIMEZONE.normalize(day), dict(
-                            (k, float(vals[i])) for i, k in enumerate(['A', 'B', 'C', 'D', '2.0TD', '3.0TD', '3.0TDVE'], 5)
+                            (k, float(vals[i])) for i, k in enumerate(coeffs_list, 5)
                         ))
                     )
                 cls._CACHE[key] = cofs

--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -252,7 +252,7 @@ class REEProfile(object):
                     n_hour += 1
                     cofs.append(Coefficent(
                         TIMEZONE.normalize(day), dict(
-                            (k, float(vals[i])) for i, k in enumerate('ABCD', 5)
+                            (k, float(vals[i])) for i, k in enumerate(['A', 'B', 'C', 'D', '20TD', '30TD', '30TDVE'], 5)
                         ))
                     )
                 cls._CACHE[key] = cofs


### PR DESCRIPTION
- Se ha creado la tarifa `T1P` para usarla como perfilador universal de PVPC.
- Se ha corregido la obtención de perfiles para las tarifas TD.