### PR TITLE
Añadir coeficiente de perfilación a la tarifa 6.2TD

### DIFF
--- a/enerdata/contracts/tariff.py
+++ b/enerdata/contracts/tariff.py
@@ -1098,7 +1098,7 @@ class T62TD(T61TD):
     def __init__(self, **kwargs):
         super(T62TD, self).__init__(**kwargs)
         self.code = '6.2TD'
-        self.cof = None
+        self.cof = '3.0TD'
 
 
 class T63TD(T61TD):


### PR DESCRIPTION
- Se ha añadido a la tarifa de acceso `6.2TD` el coeficiente de perfilación `3.0TD` como medida excepcional, para casos en los que una Distribuidora no quiera ajustar/completar una curva con el método especificado en el BOE de obtener la mejor medida del histórico.