### PR TITLE
Se ha protegido el listado de días festivos al obtener el periodo horario para una tarifa y una fecha/hora

### DIFF
--- a/enerdata/contracts/tariff.py
+++ b/enerdata/contracts/tariff.py
@@ -142,7 +142,7 @@ class Tariff(object):
 
     def get_period_by_date(self, date_time, holidays=None, magn='te'):
         station = get_station(date_time)
-        if holidays is None:
+        if not holidays:
             holidays = get_holidays(date_time.year)
         date = date_time.date()
         if (calendar.weekday(date.year, date.month, date.day) in (5, 6)


### PR DESCRIPTION
- Si se pasa un listado vacío (`[]`) como días festivos al obtener el periodo horario de una tarifa dada una fecha y una hora, la librería obtiene los días festivos que apliquen a dicha fecha y hora automáticamente en lugar de no usar días festivos.