### PR TITLE
Nuevo repositorio auxiliar de ficheros de coeficientes de perfiles de REE

### DIFF
--- a/spec/coefficients/coefficients_spec.py
+++ b/spec/coefficients/coefficients_spec.py
@@ -1,6 +1,6 @@
 from enerdata.profiles.profile import *
 from enerdata.datetime.station import *
-from enerdata.contracts.tariff import T20A
+from enerdata.contracts.tariff import T20A, T20TD
 
 
 ONE_MONTH_DATE_SET = ['1/2018']
@@ -136,10 +136,10 @@ with description('When profiling'):
         with it("must throw the exception of: Profiles from REE not found"):
             end_year = datetime.now().year
             end_month = datetime.now().month
-            start = TIMEZONE.localize(datetime(2018, 5, 1, 1))
+            start = TIMEZONE.localize(datetime(2022, 6, 1, 1))
             end = TIMEZONE.localize(datetime(end_year, end_month, 1, 0))
 
-            tariff = T20A()
+            tariff = T20TD()
             accumulated = 0
             balance = {
                 'P1': 6.8,
@@ -151,7 +151,7 @@ with description('When profiling'):
             try:
                 estimation = profile.estimate(tariff, balance)
             except Exception as err:
-                assert err.message != "Profiles from REE not found"
+                assert err.message == "Profiles from REE not found"
 
     with context("not habitual hours"):
         with it("must profile up to specific times"):


### PR DESCRIPTION
## Objetivos

- Dado que el sitio web de `REE` no es infalible para descargar los coeficientes de perfilación, se ha creado un repositorio público en GitHub para almacenar los mismos a medida que lleguen mediante Concentrador Secundario.

- Se ha implementado un reintento a la hora de obtener los coeficientes de perfilación usando el repositorio público antes mencionado.

## Relacionado

https://github.com/gisce/ree_montly_profiles
