### PR TITLE
Correcciones en el acceso al repositorio auxiliar de coeficientes de perfilación

### DIFF
--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -216,7 +216,7 @@ class Profiler(object):
 class REEProfile(object):
     HOST = 'www.ree.es'
     PATH = '/sites/default/files/simel/perff'
-    GISCE_URL = 'https://github.com/gisce/ree_montly_profiles/blob/main/perff/'
+    GISCE_URL = 'https://github.com/gisce/ree_monthly_profiles/blob/main/perff/'
     down_lock = Lock()
 
     _CACHE = {}


### PR DESCRIPTION
## Objetivos

- Corregir el nombre del repositorio auxiliar de coeficientes de perfilación, para poder consultarlo debidamente si los coeficientes desaparecen de `ESIOS` temporalmente.

## Relacionado

- Requiere https://github.com/gisce/ree_monthly_profiles/pull/1
