### PR TITLE
FIX Se añadia energia sobrante en periodo incorrecto al estimar

### DIFF
--- a/enerdata/profiles/__init__.py
+++ b/enerdata/profiles/__init__.py
@@ -2,7 +2,7 @@ try:
     from collections import Counter
 except ImportError:
     from backport_collections import Counter
-from decimal import Decimal
+from decimal import Decimal, getcontext
 
 import math
 
@@ -19,6 +19,7 @@ def my_round(x, d=0):
 class Dragger(Counter):
 
     def drag(self, number, key='default'):
+        getcontext().prec = 10  # Between 6 and 10 to get same behaviour in Python 2.7 and Python 3.11
         if number == 0 and abs(self[key]) == Decimal('0.5'):
             # Avoid oscillation between -1 and 1 and dragging 0.5 and -0.5
             return number

--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -636,7 +636,7 @@ class Profile(object):
                 dt = gap - timedelta(minutes=1)
                 period = tariff.get_period_by_date(dt)
 
-                drag_key = "default" if not self.drag_by_periods else period.code
+                drag_key = period.code if self.drag_by_periods else "default"
 
                 gap_cof = cofs.get(gap).cof[tariff.cof]
                 energy = energy_per_period[period.code]

--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -574,15 +574,11 @@ class Profile(object):
 
     def estimate(self, tariff, balance):
         assert isinstance(tariff, Tariff)
-        logger.debug('Estimating for tariff: {0}'.format(
-            tariff.code
-        ))
+        logger.debug('Estimating for tariff: {0}'.format(tariff.code))
 
         # Adapt balance for simplified T30A with just one period
         if isinstance(tariff, T30A_one_period) or isinstance(tariff, T31A_one_period):
-            balance = {
-                "P1": sum([values for values in balance.values()])
-            }
+            balance = {"P1": sum([values for values in balance.values()])}
         # Adapt T31A6P adding P4 to P1
         if isinstance(tariff, T31A) and balance.get('P4', 0) > 0:
             balance['P1'] += balance['P4']
@@ -593,13 +589,10 @@ class Profile(object):
         end = self.end_date
         # - REE cofs get from (year/month)
         # - Simel cofs get from (year/month/day hour) - can't substract one day
-        if self.first_day_of_month or not issubclass(self.profile_class,
-                                                     REEProfile):
+        if self.first_day_of_month or not issubclass(self.profile_class, REEProfile):
             cofs = self.profile_class.get_range(start, end)
         else:
-            cofs = self.profile_class.get_range(
-                start, end - relativedelta(days=1)
-            )
+            cofs = self.profile_class.get_range(start, end - relativedelta(days=1))
         cofs = Coefficients(cofs)
         cofs_per_period = Counter()
 
@@ -609,9 +602,7 @@ class Profile(object):
             gap_cof = cofs.get(dt)
             cofs_per_period[period.code] += gap_cof.cof[tariff.cof]
 
-        logger.debug('Coefficients per period calculated: {0}'.format(
-            cofs_per_period
-        ))
+        logger.debug('Coefficients per period calculated: {0}'.format(cofs_per_period))
 
         energy_per_period = self.get_estimable_consumption(tariff, balance)
         energy_per_period_rem = energy_per_period.copy()
@@ -630,9 +621,7 @@ class Profile(object):
             dragger.drag(self.accumulated, key=init_drag_key)
 
             for idx, gap in enumerate(self.gaps):
-                logger.debug('Gap {0}/{1}'.format(
-                    idx + 1, len(self.gaps)
-                ))
+                logger.debug('Gap {0}/{1}'.format(idx + 1, len(self.gaps)))
                 dt = gap - timedelta(minutes=1)
                 period = tariff.get_period_by_date(dt)
 

--- a/enerdata/profiles/profile.py
+++ b/enerdata/profiles/profile.py
@@ -636,7 +636,7 @@ class Profile(object):
                 dt = gap - timedelta(minutes=1)
                 period = tariff.get_period_by_date(dt)
 
-                drag_key = period.code if not self.drag_by_periods else "default"
+                drag_key = "default" if not self.drag_by_periods else period.code
 
                 gap_cof = cofs.get(gap).cof[tariff.cof]
                 energy = energy_per_period[period.code]

--- a/spec/profiles/profile_spec.py
+++ b/spec/profiles/profile_spec.py
@@ -900,7 +900,7 @@ with description("An estimation"):
 
             # [!] Now estimate it using a by hour dragging
             # This scenario will raise 14 kWh (+1 kWh) of total energy with an ending accumulated of -0.5
-            total_expected = my_round(sum(balance.values())) + 1
+            total_expected = my_round(sum(balance.values()))
             expected_last_accumulated = Decimal(-0.5)
 
             self.profile = Profile(start, end, self.measures, accumulated=None, drag_by_periods=True)
@@ -914,7 +914,7 @@ with description("An estimation"):
                 )
 
             # [!] Energy must match
-            assert total_expected <= total_estimated <= total_expected + 1, \
+            assert total_expected + 1 == total_estimated, \
                 "Total energy '{}' must match the expected + 1 '{}'".format(total_estimated, total_expected + 1)
 
             # [!] Last accumulated

--- a/spec/profiles/profile_spec.py
+++ b/spec/profiles/profile_spec.py
@@ -940,7 +940,7 @@ with description("An estimation"):
                 )
 
             # [!] Energy must match
-            assert total_expected <= total_estimated_by_hour <= total_expected, \
+            assert total_expected == total_estimated_by_hour, \
                 "Total energy dragged by hour '{}' must match the expected energy '{}'".format(
                     total_estimated_by_hour, total_expected
                 )

--- a/spec/profiles/profile_spec.py
+++ b/spec/profiles/profile_spec.py
@@ -887,49 +887,70 @@ with description("An estimation"):
 
     with context("with accumulated energy"):
         with it("must handle accumulated values"):
-            accumulated = Decimal(0.136)
-            drag_by_perdiod = True
-            self.profile = Profile(self.start, self.end, self.measures, accumulated, drag_by_perdiod)
-            tariff = T21DHS()
-            periods = tariff.energy_periods
+            start = TIMEZONE.localize(datetime(2022, 9, 1, 1))
+            end = TIMEZONE.localize(datetime(2022, 9, 5, 0))
 
-            # This scenario, with an initial accumulated of 0.636 will raise a -1 total energy with an ending accumulated of 0.2999999999978
-            total_expected = 0
+            tariff = T20TD()
+            periods = tariff.energy_periods
             balance = {
                 'P1': 6.8,
                 'P2': 3,
-                'P3': 3.5,
+                'P3': 3.5
             }
-            total_expected = round(sum(balance.values()))
-            expected_last_accumulated = Decimal(0.2999999999978)
 
+            # [!] Now estimate it using a by hour dragging
+            # This scenario will raise 14 kWh (+1 kWh) of total energy with an ending accumulated of -0.5
+            total_expected = round(sum(balance.values())) + 1
+            expected_last_accumulated = Decimal(-0.5)
+
+            self.profile = Profile(start, end, self.measures, accumulated=None, drag_by_periods=True)
             estimation = self.profile.estimate(tariff, balance)
             total_estimated = sum([x.measure for x in estimation.measures])
 
             # [!] Number of hours must match
-            assert self.expected_number_of_hours == len(estimation.measures), "Number of hours '{}' must match the expected '{}'".format(len(estimation.measures), self.expected_number_of_hours)
+            assert self.expected_number_of_hours == len(estimation.measures), \
+                "Number of hours '{}' must match the expected '{}'".format(
+                    len(estimation.measures), self.expected_number_of_hours
+                )
 
             # [!] Energy must match
-            assert total_expected == total_estimated, "Total energy '{}' must match the expected '{}'".format(total_estimated, total_expected)
+            assert total_expected <= total_estimated <= total_expected + 1, \
+                "Total energy '{}' must match the expected + 1 '{}'".format(total_estimated, total_expected + 1)
 
             # [!] Last accumulated
             last_accumulated = estimation.measures[-1].accumulated
             assert '{:.6f}'.format(last_accumulated) == '{:.6f}'.format(expected_last_accumulated), \
-                "Last accumulated '{}' must match the expected '{}'".format(last_accumulated, expected_last_accumulated)
+                "Last accumulated '{}' must match the expected '{}'".format(
+                    last_accumulated, expected_last_accumulated
+                )
 
             # [!] Now estimate it using a by hour dragging
-            # total energy will be +1kWh!
-            drag_by_perdiod = False
-            # total_expected += 1
-            expected_last_accumulated = Decimal(-0.2000000000006)
+            # This scenario will raise exactly 13 kWh of total energy with an ending accumulated of 0.3
+            total_expected = round(sum(balance.values()))
+            expected_last_accumulated = Decimal(0.3)
 
-            self.profile = Profile(self.start, self.end, self.measures, accumulated, drag_by_perdiod)
+            self.profile = Profile(start, end, self.measures, accumulated=None, drag_by_periods=False)
             estimation = self.profile.estimate(tariff, balance)
             total_estimated_by_hour = sum([x.measure for x in estimation.measures])
-            last_accumulated_by_hour = estimation.measures[-1].accumulated
-            assert total_expected <= total_estimated_by_hour <= total_expected + 1, "Total energy dragged by hour '{}' must match the expected +1 '{}'".format(total_estimated_by_hour, total_expected)
-            assert '{:.6f}'.format(float(last_accumulated_by_hour)) == '{:.6f}'.format(float(expected_last_accumulated)), "Last accumulated by hour '{}' must match the expected '{}'".format(last_accumulated_by_hour, expected_last_accumulated)
 
+            # [!] Number of hours must match
+            assert self.expected_number_of_hours == len(estimation.measures), \
+                "Number of hours '{}' must match the expected '{}'".format(
+                    len(estimation.measures), self.expected_number_of_hours
+                )
+
+            # [!] Energy must match
+            assert total_expected <= total_estimated_by_hour <= total_expected, \
+                "Total energy dragged by hour '{}' must match the expected energy '{}'".format(
+                    total_estimated_by_hour, total_expected
+                )
+
+            # [!] Last accumulated
+            last_accumulated_by_hour = estimation.measures[-1].accumulated
+            assert '{:.6f}'.format(float(last_accumulated_by_hour)) == '{:.6f}'.format(float(expected_last_accumulated)), \
+                "Last accumulated by hour '{}' must match the expected '{}'".format(
+                    last_accumulated_by_hour, expected_last_accumulated
+                )
 
         with it("must handle incorrect accumulated values"):
             it_breaks = False

--- a/spec/profiles/profile_spec.py
+++ b/spec/profiles/profile_spec.py
@@ -900,7 +900,7 @@ with description("An estimation"):
 
             # [!] Now estimate it using a by hour dragging
             # This scenario will raise 14 kWh (+1 kWh) of total energy with an ending accumulated of -0.5
-            total_expected = round(sum(balance.values())) + 1
+            total_expected = my_round(sum(balance.values())) + 1
             expected_last_accumulated = Decimal(-0.5)
 
             self.profile = Profile(start, end, self.measures, accumulated=None, drag_by_periods=True)
@@ -926,7 +926,7 @@ with description("An estimation"):
 
             # [!] Now estimate it using a by hour dragging
             # This scenario will raise exactly 13 kWh of total energy with an ending accumulated of 0.3
-            total_expected = round(sum(balance.values()))
+            total_expected = my_round(sum(balance.values()))
             expected_last_accumulated = Decimal(0.3)
 
             self.profile = Profile(start, end, self.measures, accumulated=None, drag_by_periods=False)


### PR DESCRIPTION
## Comportamiento antiguo

- Al estimar la energia faltante (Wh) de una hora de una curva, si la energia estimada contenía decimales se guarda lo sobranet tras un redondeo con arrastre. El problema es que no se calcula bien el periodo donde se tenian que guardar el arrastre.
- Se ha fijado que el arrastre (dragger) tenga en cuenta máximo 10 decimales, para evitar discrepancias entre Python 2.7 y Python 3.11.

## Comportamiento nuevo

- Ahora ya se calcula bien el periodo.

## Relacionado

- Cálculos revisados simulando la perfilación de consumo ara 4 días de septiembre de 2022 con una tarifa 2.0TD.
[exemple_perfilacio.xlsx](https://github.com/gisce/enerdata/files/13367519/exemple_perfilacio.xlsx)

- Coeficientes de perfilación definitivos para septiembre de 2022.
[PERFF_202209.gz](https://github.com/gisce/enerdata/files/13353657/PERFF_202209.gz)

## Checklist

- [x] Test code
    - [x] Python 2.7
    - [x] Python 3.11
