### PR TITLE
Allow zero powers to `evaluate_powers`

### DIFF
--- a/enerdata/contracts/tariff.py
+++ b/enerdata/contracts/tariff.py
@@ -261,8 +261,10 @@ class Tariff(object):
 
         return errors
 
-    def evaluate_powers(self, powers):
-        if min(powers) <= 0:
+    def evaluate_powers(self, powers, allow_zero_power=False):
+        if not allow_zero_power and min(powers) <= 0:
+            raise NotPositivePower()
+        if allow_zero_power and min(powers) < 0:
             raise NotPositivePower()
         if not len(self.power_periods) == len(powers):
             raise IncorrectPowerNumber(len(powers), len(self.power_periods))


### PR DESCRIPTION
## Objetivos

- Necessitem permetre potències a 0 ja que hi ha clients que ja tenen contractes amb algun dels seus períodes de potència a 0.

## Comportamiento antiguo

- El 0 sempre es considerava número no positiu i saltava una excepció

## Comportamiento nuevo

- Si es passa un tercer argument allow_zero_power = True (default a False, per no afectar el comportament original) el 0 no el considera un nombre negatiu i no saltaria l'excepció.

## Relacionado

- [TASK-78433](https://erp-ti.gisnet/action?model=project.task&views=%5B%5B1326%2C%22graph%22%5D%2C%5B263%2C%22tree%22%5D%2C%5B1129%2C%22form%22%5D%5D&title=Les+meves+tasques+actuals&initialView=%7B%22id%22%3A1129%2C%22type%22%3A%22form%22%7D&action_id=1050&action_type=ir.actions.act_window&res_id=78433&treeExpandable=false&limit=80&actionRawData=%7B%22domain%22%3A%22%5B%28%27user_id%27%2C+%27%3D%27%2C+uid%29%2C+%28%27state%27%2C%27in%27%2C%28%27open%27%2C%27draft%27%29%29%5D%22%7D)
